### PR TITLE
[Discussion] [Live Share] Restrict language services to local files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,7 +38,10 @@ export function activate(context: ExtensionContext) {
 	// Options to control the language client
 	let clientOptions: LanguageClientOptions = {
 		// Register the server for plain text documents
-		documentSelector: ['yaml'],
+		documentSelector: [
+			{ language: 'yaml', scheme: 'file' },
+			{ language: 'yaml', scheme: 'untitled' }
+		],
 		synchronize: {
 			// Synchronize the setting section 'languageServerExample' to the server
 			configurationSection: ['yaml', 'http.proxy', 'http.proxyStrictSSL'],


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](https://aka.ms/vsls) adding support for "guests" to receive remote language services for YAML files, this PR simply updates the current `DocumentSelector` to be limited to `file` and `untitled` (unsaved) files. This way, when someone has the YAML extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with).

*Note: I made the same change for the [Java LSP client](https://github.com/redhat-developer/vscode-java/pull/492) as well.*