### PR TITLE
Send DynamicCustomSchemaRequestRegistration request

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,10 @@ namespace SchemaAssociationNotification {
 	export const type: NotificationType<ISchemaAssociations, any> = new NotificationType('json/schemaAssociations');
 }
 
+namespace DynamicCustomSchemaRequestRegistration {
+	export const type: NotificationType<{}, {}> = new NotificationType('yaml/registerCustomSchemaRequest');
+}
+
 export function activate(context: ExtensionContext) {
 
 	// The server is implemented in node
@@ -63,6 +67,7 @@ export function activate(context: ExtensionContext) {
 
 	client.onReady().then(() => {
 		client.sendNotification(SchemaAssociationNotification.type, getSchemaAssociation(context));
+		client.sendNotification(DynamicCustomSchemaRequestRegistration.type);
 		client.onRequest(CUSTOM_SCHEMA_REQUEST, (resource) => {
 			return schemaContributor.requestCustomSchema(resource);
 		});


### PR DESCRIPTION
Send DynamicCustomSchemaRequestRegistration request so that VSCode registers with the language server to use custom schema requests. This is because some clients were getting errors when the server was sending CustomSchemaRequest types to the client.

Corresponding PR on yaml-language-server side https://github.com/redhat-developer/yaml-language-server/pull/94