### PR TITLE
Fixed ragion markers not showing

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -22,7 +22,11 @@
 		["'", "'"]
 	],
 	"folding": {
-		"offSide": true
+		"offSide": true,
+		"markers": {
+			"start": "^\\s*#\\s*region\\b",
+			"end": "^\\s*#\\s*endregion\\b"
+		}
 	},
 	"indentationRules": {
 		"increaseIndentPattern": "^\\s*.*(:|-) ?(&amp;\\w+)?(\\{[^}\"']*|\\([^)\"']*)?$",


### PR DESCRIPTION
# Pure vscode (no ext)

![Working](https://i.imgur.com/aDT6MQN.gif)

# Only YAML Support by Red Hat ext

## Before

![Not Working](https://i.imgur.com/Ht7fodH.png)

## After

![Working](https://i.imgur.com/ZppPmFd.gif)