### PR TITLE
Fix debug flag breaking in latest VSCode

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,7 +30,7 @@ export function activate(context: ExtensionContext) {
 	let serverModule = context.asAbsolutePath(path.join('node_modules', 'yaml-language-server', 'out', 'server', 'src', 'server.js'));
 
 	// The debug options for the server
-	let debugOptions = { execArgv: ["--nolazy", "--debug=6009"] };
+	let debugOptions = { execArgv: ["--nolazy", "--inspect=6009"] };
 
 	// If the extension is launched in debug mode then the debug server options are used
 	// Otherwise the run options are used


### PR DESCRIPTION
We're writing an extension that depends on this one and when starting in debug mode within VSCode there is an error that causes our extension not to start:
<img width="392" alt="screenshot 2018-10-10 at 14 21 43" src="https://user-images.githubusercontent.com/1379888/46739655-f7d7a400-cc98-11e8-8f37-0cd7a63f19dd.png">
<img width="395" alt="screenshot 2018-10-10 at 14 21 46" src="https://user-images.githubusercontent.com/1379888/46739671-002fdf00-cc99-11e8-8a05-e97340fc1fa7.png">

I've tracked it down to an outdated `--debug` flag passed to the language server running in Node. Now that VSCode is running v8.9.3 that has switched to `--inspect`.

After this change starting this extension with the "Launch Extension" task then works:
<img width="723" alt="screenshot 2018-10-10 at 14 22 05" src="https://user-images.githubusercontent.com/1379888/46739822-4be28880-cc99-11e8-917b-407762fc6157.png">
