### PR TITLE
Update deprecated VSCode configuration

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,7 @@
 	// for the documentation about the extensions.json format
 	"recommendations": [
 		// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
-		"eg2.tslint",
+		"ms-vscode.vscode-typescript-tslint-plugin",
 		"EditorConfig.EditorConfig"
 	]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,8 +1,8 @@
-// A launch configuration that compiles the extension and then opens it inside a new window
 {
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"configurations": [
 		{
+			// A launch configuration that compiles the extension and then opens it inside a new window
 			"name": "Launch Extension",
 			"type": "extensionHost",
 			"request": "launch",
@@ -11,9 +11,10 @@
 			"stopOnEntry": false,
 			"sourceMaps": true,
 			"outFiles": [ "${workspaceRoot}/out/src/**/*.js" ],
-			"preLaunchTask": "npm"
+			"preLaunchTask": "compile typescript"
 		},
 		{
+			// A launch configuration that compiles the extension and runs mocha unit tests
 			"type": "node",
 			"request": "launch",
 			"name": "Launch Tests",
@@ -28,7 +29,7 @@
 				"ts-node/register",
 				"${workspaceRoot}/test/*.test.ts"
 			],
-			"preLaunchTask": "npm"
+			"preLaunchTask": "compile typescript"
 		}
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,30 +1,23 @@
-// Available variables which can be used inside of strings.
-// ${workspaceRoot}: the root folder of the team
-// ${file}: the current opened file
-// ${fileBasename}: the current opened file's basename
-// ${fileDirname}: the current opened file's dirname
-// ${fileExtname}: the current opened file's extension
-// ${cwd}: the current working directory of the spawned process
-
-// A task runner that calls a custom npm script that compiles the extension.
 {
-	"version": "0.1.0",
-
-	// we want to run npm
-	"command": "npm",
-
-	// the command is a shell script
-	"isShellCommand": true,
-
-	// show the output window only if unrecognized errors occur.
-	"showOutput": "silent",
-
-	// we run the custom script "compile" as defined in package.json
-	"args": ["run", "compile", "--loglevel", "silent"],
-
-	// The tsc compiler is started in watching mode
-	"isBackground": true,
-
-	// use the standard tsc in watch mode problem matcher to find compile problems in the output.
-	"problemMatcher": "$tsc-watch"
+	// See https://go.microsoft.com/fwlink/?LinkId=733558
+	// for the documentation about the tasks.json format
+	"version": "2.0.0",
+	"tasks": [
+		// A task runner that calls a custom npm script that compiles the extension.
+		{
+			"label": "compile typescript",
+			// the command is a shell script
+			"type": "shell",
+			// we run the custom npm script "compile" as defined in package.json
+			"command": "npm run compile --loglevel silent",
+			// show the output window only if unrecognized errors occur.
+			"presentation": {
+				"reveal": "silent",
+			},
+			// The tsc compiler is started in watching mode
+			"isBackground": true,
+			// use the standard tsc in watch mode problem matcher to find compile problems in the output.
+			"problemMatcher": "$tsc-watch"
+		}
+	]
 }


### PR DESCRIPTION
* Rewrote tasks.json in the new format (as the old format is not supported for multi-root workspaces)
* Updated launch.json to newer version (no changes required) and adapted to change in tasks.json
* Changed the workspace tslint extension recommendation from deprecated to current one