### PR TITLE
Add workspace YAML files request handler

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,8 @@ namespace DynamicCustomSchemaRequestRegistration {
 	export const type: NotificationType<{}, {}> = new NotificationType('yaml/registerCustomSchemaRequest');
 }
 
+const WORKSPACE_FILES_REQUEST = 'custom/workspace/yamlfiles';
+
 export function activate(context: ExtensionContext) {
 	// The YAML language server is implemented in node
 	let serverModule = context.asAbsolutePath(path.join('node_modules', 'yaml-language-server', 'out', 'server', 'src', 'server.js'));
@@ -79,6 +81,12 @@ export function activate(context: ExtensionContext) {
 		});
 		client.onRequest(CUSTOM_CONTENT_REQUEST, (uri) => {
 			return schemaContributor.requestCustomSchemaContent(uri);
+		});
+		// If the server asks, find all YAML files in the workspace and return an array of paths
+		client.onRequest(WORKSPACE_FILES_REQUEST, () => {
+			return workspace.findFiles('**/*.{ey,y}{m,am}l')
+							.then(yamlFiles => yamlFiles.map(yamlFile => yamlFile.fsPath),
+								  error => console.error('Failed to search workspace for YAML files: ' + error));
 		});
 	});
 


### PR DESCRIPTION
This allows the server to send a 'custom/workspace/yamlfiles' request and receive a list of absolute paths to all YAML files in the workspace.

Useful for external tools that need to know the file paths to provide smarter validation / auto-completion than feasible with JSON schema.
The implementation would be highly specific to the tools themselves, so this isn't a complete, but an enabling feature.