### PR TITLE
Support URL schemes other than file or untitled

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,8 +43,7 @@ export function activate(context: ExtensionContext) {
 	let clientOptions: LanguageClientOptions = {
 		// Register the server for on disk and newly created YAML documents
 		documentSelector: [
-			{ language: 'yaml', scheme: 'file' },
-			{ language: 'yaml', scheme: 'untitled' }
+			{ language: 'yaml' }
 		],
 		synchronize: {
 			// Synchronize these setting sections with the server


### PR DESCRIPTION
In the Kubernetes extension we would like to get YAML hover on 'live' resources, viewed on the cluster via a `FileSystemProvider` rather than saved to the filesystem first.  The YAML extension currently registers the language server only for filesystem and untitled documents.  This PR amends that to register it for all YAML documents.