### PR TITLE
Introduce API for overriding json objects coming from contributors

### DIFF
--- a/test/completion.test.ts
+++ b/test/completion.test.ts
@@ -25,7 +25,8 @@ describe('Completion should work in multiple different scenarios', () => {
 			items: [
 				{
                     label: "my_key",
-                    kind: 9
+                    kind: 9,
+                    documentation: "My string"
                 }
 			]
 		});
@@ -40,7 +41,8 @@ describe('Completion should work in multiple different scenarios', () => {
 			items: [
 				{
                     label: "version",
-                    kind: 9
+                    kind: 9,
+                    documentation: "A stringy string string"
                 }
 			]
 		});		

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -79,6 +79,7 @@ export async function testCompletion(
 		const actualItem = sortedActualCompletionList[i];
 		assert.equal(actualItem.label, expectedItem.label);
 		assert.equal(actualItem.kind, expectedItem.kind);
+		assert.equal(actualItem.documentation, expectedItem.documentation);
 	});
 }
 
@@ -129,3 +130,16 @@ export async function testDiagnostics(docUri: vscode.Uri, expectedDiagnostics: v
 	  assert.equal(actualDiagnostic.severity, expectedDiagnostic.severity)
 	});
 }
+
+export const schemaJSON = JSON.stringify({
+	type: "object",
+	properties: {
+		version: {
+			type: "string",
+			description: "A stringy string string",
+			enum: [
+				"test"
+			]
+		}
+	}
+});

--- a/test/schemaModification.test.ts
+++ b/test/schemaModification.test.ts
@@ -28,7 +28,8 @@ describe('Schema sections can be modified in memory', () => {
 			items: [
 				{
                     label: "my_value",
-                    kind: 11
+                    kind: 11,
+                    documentation: 'My string'
                 }
 			]
         });
@@ -50,15 +51,18 @@ describe('Schema sections can be modified in memory', () => {
             items: [
                 {
                     label: "my_apple",
-                    kind: 11
+                    kind: 11,
+                    documentation: 'My string'
                 },
                 {
                     label: "my_banana",
-                    kind: 11
+                    kind: 11,
+                    documentation: 'My string'
                 },
                 {
                     label: "my_carrot",
-                    kind: 11
+                    kind: 11,
+                    documentation: 'My string'
                 }
             ]
         });
@@ -77,7 +81,8 @@ describe('Schema sections can be modified in memory', () => {
 			items: [
 				{
                     label: "my_test1",
-                    kind: 11
+                    kind: 11,
+                    documentation: 'My string'
                 },
                 {
                     label: "my_test2",

--- a/test/schemaProvider.test.ts
+++ b/test/schemaProvider.test.ts
@@ -4,7 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 
 import * as vscode from 'vscode';
-import { getDocUri, activate, testCompletion, testHover, testDiagnostics, sleep } from './helper';
+import { getDocUri, activate, testCompletion, testHover, testDiagnostics, sleep, schemaJSON } from './helper';
 import { Uri } from 'vscode';
 
 describe('Tests for schema provider feature', () => {
@@ -19,7 +19,8 @@ describe('Tests for schema provider feature', () => {
 			items: [
 				{
                     label: "version",
-                    kind: 9
+					kind: 9,
+					documentation: "A stringy string string"
                 }
 			]
 		});
@@ -59,27 +60,14 @@ describe('Tests for schema provider feature', () => {
 
 const SCHEMA = "myschema";
 
-const schemaJSON = JSON.stringify({
-	type: "object",
-	properties: {
-		version: {
-			type: "string",
-			description: "A stringy string string",
-			enum: [
-				"test"
-			]
-		}
-	}
-});
-
-function onRequestSchemaURI(resource: string): string | undefined {
-	if (resource.endsWith('.yaml')) {
+export function onRequestSchemaURI(resource: string): string | undefined {
+	if (resource.endsWith('basic.yaml') || resource.endsWith('completion.yaml')) {
 		return `${SCHEMA}://schema/porter`;
 	}
 	return undefined;
 }
 
-function onRequestSchemaContent(schemaUri: string): string | undefined {
+export function onRequestSchemaContent(schemaUri: string): string | undefined {
 	const parsedUri = Uri.parse(schemaUri);
 	if (parsedUri.scheme !== SCHEMA) {
 		return undefined;

--- a/test/schemaProviderModification.test.ts
+++ b/test/schemaProviderModification.test.ts
@@ -1,0 +1,69 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Red Hat, Inc. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as vscode from 'vscode';
+import { getDocUri, activate, testCompletion } from './helper';
+import { Uri } from 'vscode';
+import { ExtensionAPI } from '../src/schema-extension-api';
+
+describe('Tests for schema modifier feature', () => {
+	const docUri = getDocUri('completion/completion_modification.yaml');
+
+    it('modification happens before being sent back to language server', async () => {
+		const client: ExtensionAPI = await activate(docUri);
+
+		client.registerContributor(SCHEMA, onRequestSchemaURI, onRequestSchemaContent);
+        client.registerCustomSchemaContentModifier(SCHEMA, objStringified => {
+            const obj = JSON.parse(objStringified);
+            obj.properties.version.description = 'hello world!';
+            return JSON.stringify(obj);
+        });
+
+        await testCompletion(docUri, new vscode.Position(0, 0), {
+			items: [
+				{
+                    label: "version",
+                    documentation: 'hello world!',
+                    kind: 9
+                }
+			]
+		});
+                
+
+	});
+	
+});
+
+const SCHEMA = "myotherschema";
+
+export function onRequestSchemaURI(resource: string): string | undefined {
+	if (resource.endsWith('completion_modification.yaml')) {
+		return `${SCHEMA}://schema/porter`;
+	}
+	return undefined;
+}
+
+export function onRequestSchemaContent(schemaUri: string): string | undefined {
+	const parsedUri = Uri.parse(schemaUri);
+	if (parsedUri.scheme !== SCHEMA) {
+		return undefined;
+	}
+	if (!parsedUri.path || !parsedUri.path.startsWith('/')) {
+		return undefined;
+	}
+
+	return schemaJSON;
+}
+
+export const schemaJSON = JSON.stringify({
+	type: "object",
+	properties: {
+		version: {
+			type: "string",
+			description: "my description",
+		}
+	}
+});
+


### PR DESCRIPTION
This introduces some new API that allows you to override schemas that come from contributors using the registerContributor API.

The way it works is that if `registerContributor` registers with a scheme "kubernetes" and then you use `registerCustomSchemaContentModifier` with scheme "kubernetes" and your callback function, the callback function will be called with the schema content after a schema content request has been made BUT before it sends the schema back to the language server. This means you can intercept the schema and control it however you'd like.