### PR TITLE
Allow multiple matches for one yaml file with requestCustomSchema

### DIFF
--- a/src/schema-extension-api.ts
+++ b/src/schema-extension-api.ts
@@ -71,20 +71,22 @@ class SchemaExtensionAPI implements ExtensionAPI {
     }
 
 	/**
-	 * Call requestSchema for each provider and find the first one who reports he can provide the schema.
+	 * Call requestSchema for each provider and finds all matches.
 	 *
 	 * @param {string} resource
 	 * @returns {string} the schema uri
 	 */
-	public requestCustomSchema(resource: string): string {
+	public requestCustomSchema(resource: string): string[] {
+        const matches = [];
         for (let customKey of Object.keys(this._customSchemaContributors)) {
             const contributor = this._customSchemaContributors[customKey];
             const uri = contributor.requestSchema(resource);
 
             if (uri) {
-                return uri;
+                matches.push(uri);
             }
         }
+        return matches;
     }
 
 	/**

--- a/test/schemaProvider.test.ts
+++ b/test/schemaProvider.test.ts
@@ -14,7 +14,7 @@ describe('Tests for schema provider feature', () => {
     it('completion, hover, and validation work with registered contributor schema', async () => {
 		const client = await activate(docUri);
 
-		client.registerContributor(SCHEMA, onRequestSchemaURI, onRequestSchemaContent);
+		client.registerContributor(SCHEMA, onRequestSchema1URI, onRequestSchema1Content);
 		await testCompletion(docUri, new vscode.Position(0, 0), {
 			items: [
 				{
@@ -44,7 +44,7 @@ describe('Tests for schema provider feature', () => {
 	
 	it('Validation occurs automatically with registered contributor schema', async () => {
 		const client = await activate(hoverUri);
-		client.registerContributor(SCHEMA, onRequestSchemaURI, onRequestSchemaContent);
+		client.registerContributor(SCHEMA, onRequestSchema1URI, onRequestSchema1Content);
 
 		await sleep(2000); // Wait for the diagnostics to compute on this file
 		await testDiagnostics(hoverUri, [
@@ -54,10 +54,33 @@ describe('Tests for schema provider feature', () => {
 				severity: 0
 			}
 		]);
+	});
+
+	it('Multiple contributors can match one file', async () => {
+		const client = await activate(docUri);
+		client.registerContributor(SCHEMA2, onRequestSchema2URI, onRequestSchema2Content);
+		client.registerContributor(SCHEMA3, onRequestSchema3URI, onRequestSchema3Content);
+
+		await testCompletion(docUri, new vscode.Position(0, 0), {
+			items: [
+				{
+                    label: "apple",
+					kind: 9,
+					documentation: "An apple"
+				},
+				{
+                    label: "version",
+					kind: 9,
+					documentation: "A stringy string string"
+                }
+			]
+		});
     });
 });
 
 const SCHEMA = "myschema";
+const SCHEMA2 = "myschema2";
+const SCHEMA3 = "myschema3";
 
 const schemaJSON = JSON.stringify({
 	type: "object",
@@ -72,21 +95,39 @@ const schemaJSON = JSON.stringify({
 	}
 });
 
-function onRequestSchemaURI(resource: string): string | undefined {
-	if (resource.endsWith('.yaml')) {
+function onRequestSchema1URI(resource: string): string | undefined {
+	if (resource.endsWith('completion.yaml') || resource.endsWith('basic.yaml')) {
 		return `${SCHEMA}://schema/porter`;
 	}
 	return undefined;
 }
 
-function onRequestSchemaContent(schemaUri: string): string | undefined {
-	const parsedUri = Uri.parse(schemaUri);
-	if (parsedUri.scheme !== SCHEMA) {
-		return undefined;
-	}
-	if (!parsedUri.path || !parsedUri.path.startsWith('/')) {
-		return undefined;
-	}
+function onRequestSchema1Content(schemaUri: string): string | undefined {
+	return schemaJSON;
+}
 
+const schemaJSON2 = JSON.stringify({
+	"type": "object",
+	"properties": {
+		"apple": {
+			"type": "string",
+			"description": "An apple",
+		}
+	}
+});
+
+function onRequestSchema2URI(resource: string): string | undefined {
+	return `${SCHEMA2}://schema/porter`;
+}
+
+function onRequestSchema2Content(schemaUri: string): string | undefined {
+	return schemaJSON2;
+}
+
+function onRequestSchema3URI(resource: string): string | undefined {
+	return `${SCHEMA3}://schema/porter`;
+}
+
+function onRequestSchema3Content(schemaUri: string): string | undefined {
 	return schemaJSON;
 }


### PR DESCRIPTION
This PR allows a yaml file to be matched with multiple contributors.

This is then handled on the yaml language server side by https://github.com/redhat-developer/yaml-language-server/pull/227