### PR TITLE
Added a "yamlValidation" example in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,19 @@ e.g.
 - The entrance point for `yaml.schemas` is location in [user and workspace settings](https://code.visualstudio.com/docs/getstarted/settings#_creating-user-and-workspace-settings)
 - Supports schemas through [schema store](http://schemastore.org/json/) as well as any other schema url
 - Supports 'yamlValidation' point which allows you to contribute a schema for a specific type of yaml file (Similar to [jsonValidation](https://code.visualstudio.com/docs/extensionAPI/extension-points#_contributesjsonvalidation))
+e.g.
+```JSON
+{
+  "contributes": {
+    "yamlValidation": [
+      {
+        "fileMatch": "yourfile.yml",
+        "url": "./schema.json"
+      }
+    ]
+  }
+}
+```
 
 This extension allows you to specify json schemas that you want to validate against the yaml that you write. In the vscode user and workspace preferences you can set a url and a glob pattern that you want to validate against the schema. Kubernetes and kedge are optional fields. They do not require a url as the language server will provide that. You just need the keywords kubernetes/kedge and a glob pattern.
 


### PR DESCRIPTION
This PR adds a configuration example in README.md, to use "yamlValidation" feature in package.json from another extension