### PR TITLE
Enable user to permit & collect usage metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,12 @@
     ],
     "configuration": {
       "properties": {
+        "yaml.collectTelemetryData": {
+          "Title": "Enable Telemetry",
+          "type": "boolean",
+          "default": true,
+          "description": "Enable usage data and errors to be sent to Red Hat online services"
+        },
         "yaml.trace.server": {
           "type": "string",
           "enum": [
@@ -170,6 +176,8 @@
     "vscode": "^1.1.34"
   },
   "dependencies": {
+    "@types/analytics-node": "^3.1.2",
+    "analytics-node": "3.4.0-beta.1",
     "vscode-languageclient": "5.2.1",
     "vscode-nls": "^3.2.1",
     "vscode-uri": "^2.0.3",

--- a/src/util/metrics.ts
+++ b/src/util/metrics.ts
@@ -1,0 +1,35 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+
+import * as vscode from 'vscode';
+
+import segmentanalytics = require('analytics-node');
+
+const segmentToken = 'e2CYiNSApF1YqFUVPWtOhjf02W6ouAc4';
+
+export class Metrics {
+
+  static shallSendMetrics()  {
+    if (vscode.workspace.getConfiguration("yaml").get("collectTelemetryData")) {
+        return true;
+    }
+    return false;
+  }
+
+  public static publishUsageMetrics(message: string, yamlInfo: string) {
+    const analytics = new segmentanalytics(segmentToken);
+
+      if (Metrics.shallSendMetrics()) {
+           analytics.track({
+            userId: 'anonymous',
+            event: message,
+            properties: {
+              "json-schema": yamlInfo
+            }
+          });
+      }
+  }
+}


### PR DESCRIPTION
This PR enables the following :
1) Enable user to permit for start collecting usage metrics
2) Collects the JSON schemas used for validating YAML files
3) No user specific information nor any file (eg: yaml) content is collected.