### PR TITLE
Add label for scheme contributions

### DIFF
--- a/src/schema-extension-api.ts
+++ b/src/schema-extension-api.ts
@@ -1,47 +1,49 @@
 import { URI } from 'vscode-uri'
 import { LanguageClient, RequestType } from 'vscode-languageclient';
+import * as vscode from 'vscode';
 
 interface SchemaContributorProvider {
-    readonly requestSchema: (resource: string) => string;
-    readonly requestSchemaContent: (uri: string) => string;
+	readonly requestSchema: (resource: string) => string;
+	readonly requestSchemaContent: (uri: string) => string;
+	readonly label?: string;
 }
 
 export enum MODIFICATION_ACTIONS {
-    'delete',
-    'add'
+	'delete',
+	'add'
 }
 
 export interface SchemaAdditions {
-    schema: string,
-    action: MODIFICATION_ACTIONS.add,
-    path: string,
-    key: string,
-    content: any
+	schema: string,
+	action: MODIFICATION_ACTIONS.add,
+	path: string,
+	key: string,
+	content: any
 }
 
 export interface SchemaDeletions {
-    schema: string,
-    action: MODIFICATION_ACTIONS.delete,
-    path: string,
-    key: string
+	schema: string,
+	action: MODIFICATION_ACTIONS.delete,
+	path: string,
+	key: string
 }
 
 namespace SchemaModificationNotification {
-    export const type: RequestType<SchemaAdditions | SchemaDeletions, void, { }, { }> = new RequestType('json/schema/modify');
+	export const type: RequestType<SchemaAdditions | SchemaDeletions, void, {}, {}> = new RequestType('json/schema/modify');
 }
 
 export interface ExtensionAPI {
-    registerContributor(schema: string, requestSchema: (resource: string) => string, requestSchemaContent: (uri: string) => string): boolean;
-    modifySchemaContent(schemaModifications: SchemaAdditions | SchemaDeletions): Promise<void>;
+	registerContributor(schema: string, requestSchema: (resource: string) => string, requestSchemaContent: (uri: string) => string, label?: string): boolean;
+	modifySchemaContent(schemaModifications: SchemaAdditions | SchemaDeletions): Promise<void>;
 }
 
 class SchemaExtensionAPI implements ExtensionAPI {
-    private _customSchemaContributors: { [index: string]: SchemaContributorProvider } = {};
-    private _yamlClient: LanguageClient;
+	private _customSchemaContributors: { [index: string]: SchemaContributorProvider } = {};
+	private _yamlClient: LanguageClient;
 
-    constructor(client: LanguageClient) {
-        this._yamlClient = client;
-    }
+	constructor(client: LanguageClient) {
+		this._yamlClient = client;
+	}
 
 	/**
 	 * Register a custom schema provider
@@ -49,26 +51,37 @@ class SchemaExtensionAPI implements ExtensionAPI {
 	 * @param {string} the provider's name
 	 * @param requestSchema the requestSchema function
 	 * @param requestSchemaContent the requestSchemaContent function
+	 * @param label the content label, yaml key value pair, like 'apiVersion:some.api/v1'
 	 * @returns {boolean}
 	 */
-    public registerContributor(schema: string,
-            requestSchema: (resource: string) => string,
-            requestSchemaContent: (uri: string) => string): boolean {
-        if (this._customSchemaContributors[schema]) {
-            return false;
-        }
+	public registerContributor(schema: string,
+		requestSchema: (resource: string) => string,
+		requestSchemaContent: (uri: string) => string,
+		label?: string): boolean {
+		if (this._customSchemaContributors[schema]) {
+			return false;
+		}
 
-        if (!requestSchema) {
-            throw new Error("Illegal parameter for requestSchema.");
-        }
+		if (!requestSchema) {
+			throw new Error("Illegal parameter for requestSchema.");
+		}
 
-        this._customSchemaContributors[schema] = <SchemaContributorProvider>{
-            requestSchema,
-            requestSchemaContent
-        };
+		if (label) {
+			let [first, second] = label.split(':');
+			if (first && second) {
+				second = second.trim();
+				second = second.replace('.', '\\.');
+				label = `${first}:[\t ]+${second}`;
+			}
+		}
+		this._customSchemaContributors[schema] = <SchemaContributorProvider>{
+			requestSchema,
+			requestSchemaContent,
+			label
+		};
 
-        return true;
-    }
+		return true;
+	}
 
 	/**
 	 * Call requestSchema for each provider and finds all matches.
@@ -77,17 +90,30 @@ class SchemaExtensionAPI implements ExtensionAPI {
 	 * @returns {string} the schema uri
 	 */
 	public requestCustomSchema(resource: string): string[] {
-        const matches = [];
-        for (let customKey of Object.keys(this._customSchemaContributors)) {
-            const contributor = this._customSchemaContributors[customKey];
-            const uri = contributor.requestSchema(resource);
+		const matches = [];
+		for (let customKey of Object.keys(this._customSchemaContributors)) {
+			const contributor = this._customSchemaContributors[customKey];
+			let uri: string;
+			if (contributor.label && vscode.workspace.textDocuments) {
+				const labelRegexp = new RegExp(contributor.label, 'g');
+				for (const doc of vscode.workspace.textDocuments) {
+					if (doc.uri.toString() === resource) {
+						if (labelRegexp.test(doc.getText())) {
+							uri = contributor.requestSchema(resource);
+							return [uri];
+						}
+					}
+				}
+			}
 
-            if (uri) {
-                matches.push(uri);
-            }
-        }
-        return matches;
-    }
+			uri = contributor.requestSchema(resource);
+
+			if (uri) {
+				matches.push(uri);
+			}
+		}
+		return matches;
+	}
 
 	/**
 	 * Call requestCustomSchemaContent for named provider and get the schema content.
@@ -95,20 +121,20 @@ class SchemaExtensionAPI implements ExtensionAPI {
 	 * @param {string} uri the schema uri returned from requestSchema.
 	 * @returns {string} the schema content
 	 */
-    public requestCustomSchemaContent(uri: string): string {
-        if (uri) {
-            let _uri = URI.parse(uri);
+	public requestCustomSchemaContent(uri: string): string {
+		if (uri) {
+			let _uri = URI.parse(uri);
 
-            if (_uri.scheme && this._customSchemaContributors[_uri.scheme] &&
-                this._customSchemaContributors[_uri.scheme].requestSchemaContent) {
-                return this._customSchemaContributors[_uri.scheme].requestSchemaContent(uri);
-            }
-        }
-    }
+			if (_uri.scheme && this._customSchemaContributors[_uri.scheme] &&
+				this._customSchemaContributors[_uri.scheme].requestSchemaContent) {
+				return this._customSchemaContributors[_uri.scheme].requestSchemaContent(uri);
+			}
+		}
+	}
 
-    public async modifySchemaContent(schemaModifications: SchemaAdditions | SchemaDeletions) {
-        return this._yamlClient.sendRequest(SchemaModificationNotification.type, schemaModifications);
-    }
+	public async modifySchemaContent(schemaModifications: SchemaAdditions | SchemaDeletions) {
+		return this._yamlClient.sendRequest(SchemaModificationNotification.type, schemaModifications);
+	}
 }
 
 // constants

--- a/src/schema-extension-api.ts
+++ b/src/schema-extension-api.ts
@@ -1,6 +1,6 @@
 import { URI } from 'vscode-uri'
 import { LanguageClient, RequestType } from 'vscode-languageclient';
-import * as vscode from 'vscode';
+import { workspace } from 'vscode';
 
 interface SchemaContributorProvider {
 	readonly requestSchema: (resource: string) => string;
@@ -94,9 +94,9 @@ class SchemaExtensionAPI implements ExtensionAPI {
 		for (let customKey of Object.keys(this._customSchemaContributors)) {
 			const contributor = this._customSchemaContributors[customKey];
 			let uri: string;
-			if (contributor.label && vscode.workspace.textDocuments) {
+			if (contributor.label && workspace.textDocuments) {
 				const labelRegexp = new RegExp(contributor.label, 'g');
-				for (const doc of vscode.workspace.textDocuments) {
+				for (const doc of workspace.textDocuments) {
 					if (doc.uri.toString() === resource) {
 						if (labelRegexp.test(doc.getText())) {
 							uri = contributor.requestSchema(resource);


### PR DESCRIPTION
In case when two(or more) extensions wants to contribute JSON Scheme for same file, we need a way to chose which scheme LS will use. This PR solve that problem by adding additional optional parameter for `registerContributor` method.
That parameter is `label`, it should contains yaml key value pair, that pair will be used to check file content and LS receive only one JSON scheme, if label is match.

Fix: https://github.com/redhat-developer/yaml-language-server/issues/267 