### PR TITLE
Allow tests to run on jenkins again

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,9 @@
 #!/usr/bin/env groovy
 
 def installBuildRequirements(){
-	def nodeHome = tool 'nodejs-7.7.4'
+	def nodeHome = tool 'nodejs-10.9.0'
 	env.PATH="${env.PATH}:${nodeHome}/bin"
-	sh "npm install -g typescript@3.0.0-dev.20180626"
+	sh "npm install -g typescript"
 	sh "npm install -g vsce"
 }
 
@@ -12,7 +12,7 @@ def buildVscodeExtension(){
 	sh "npm run vscode:prepublish"
 }
 
-node('rhel7'){
+node('rhel8'){
 
 	stage 'Checkout vscode-yaml code'
 	deleteDir()
@@ -40,7 +40,7 @@ node('rhel7'){
 	stash name:'vsix', includes:vsix[0].path
 }
 
-node('rhel7'){
+node('rhel8'){
 	timeout(time:5, unit:'DAYS') {
 		input message:'Approve deployment?', submitter: 'jpinkney'
 	}

--- a/test/testRunner.ts
+++ b/test/testRunner.ts
@@ -22,7 +22,6 @@ async function main() {
 			extensionTestsPath,
 			launchArgs: [
 				"--disable-extensions",
-				"--disable-gpu",
 				"."
 			]
 		});


### PR DESCRIPTION
This PR is grabbed from: https://github.com/snjeza/vscode-yaml/commit/95727e3f9171af75d1668265633fd22b692a090b

and then cherry-picked onto master so that tests will pass
(cherry picked from commit 95727e3f9171af75d1668265633fd22b692a090b)

Supercedes https://github.com/redhat-developer/vscode-yaml/pull/316