### PR TITLE
Catch errors that can be thrown by registered schema providers #323

### DIFF
--- a/src/schema-extension-api.ts
+++ b/src/schema-extension-api.ts
@@ -92,24 +92,28 @@ class SchemaExtensionAPI implements ExtensionAPI {
 	public requestCustomSchema(resource: string): string[] {
 		const matches = [];
 		for (let customKey of Object.keys(this._customSchemaContributors)) {
-			const contributor = this._customSchemaContributors[customKey];
-			let uri: string;
-			if (contributor.label && workspace.textDocuments) {
-				const labelRegexp = new RegExp(contributor.label, 'g');
-				for (const doc of workspace.textDocuments) {
-					if (doc.uri.toString() === resource) {
-						if (labelRegexp.test(doc.getText())) {
-							uri = contributor.requestSchema(resource);
-							return [uri];
+			try {
+				const contributor = this._customSchemaContributors[customKey];
+				let uri: string;
+				if (contributor.label && workspace.textDocuments) {
+					const labelRegexp = new RegExp(contributor.label, 'g');
+					for (const doc of workspace.textDocuments) {
+						if (doc.uri.toString() === resource) {
+							if (labelRegexp.test(doc.getText())) {
+								uri = contributor.requestSchema(resource);
+								return [uri];
+							}
 						}
 					}
 				}
-			}
 
-			uri = contributor.requestSchema(resource);
+				uri = contributor.requestSchema(resource);
 
-			if (uri) {
-				matches.push(uri);
+				if (uri) {
+					matches.push(uri);
+				}
+			} catch (error) {
+				console.log(`Error thrown while requesting schema ` + error);
 			}
 		}
 		return matches;

--- a/test/schemaProvider.test.ts
+++ b/test/schemaProvider.test.ts
@@ -5,7 +5,6 @@
 
 import * as vscode from 'vscode';
 import { getDocUri, activate, testCompletion, testHover, testDiagnostics, sleep } from './helper';
-import { Uri } from 'vscode';
 
 describe('Tests for schema provider feature', () => {
 	const docUri = getDocUri('completion/completion.yaml');
@@ -134,6 +133,23 @@ describe('Tests for schema provider feature', () => {
                 }
 			]
 		});
+	});
+
+	it('Multiple contributors with one throwing an error', async () => {
+		const client = await activate(docUri);
+		client._customSchemaContributors = {};
+		client.registerContributor(SCHEMA2, onRequestSchema2URI, onRequestSchema2Content);
+		client.registerContributor("schemathrowingerror", onRequestSchemaURIThrowError, onRequestSchemaContentThrowError);
+
+		await testCompletion(docUri, new vscode.Position(0, 0), {
+			items: [
+				{
+                    label: "apple",
+					kind: 9,
+					documentation: "An apple"
+				}
+			]
+		});
     });
 });
 
@@ -159,6 +175,14 @@ function onRequestSchema1URI(resource: string): string | undefined {
 		return `${SCHEMA}://schema/porter`;
 	}
 	return undefined;
+}
+
+function onRequestSchemaURIThrowError(resource: string): string | undefined {
+	throw new Error('test what happens when an error is trhown and not caught');
+}
+
+function onRequestSchemaContentThrowError(schemaUri: string): string | undefined {
+	throw new Error('test what happens when an error is trhown and not caught');
 }
 
 function onRequestSchema1Content(schemaUri: string): string | undefined {

--- a/test/schemaProvider.test.ts
+++ b/test/schemaProvider.test.ts
@@ -144,7 +144,7 @@ describe('Tests for schema provider feature', () => {
 		await testCompletion(docUri, new vscode.Position(0, 0), {
 			items: [
 				{
-                    label: "apple",
+                  label: "apple",
 					kind: 9,
 					documentation: "An apple"
 				}
@@ -178,11 +178,11 @@ function onRequestSchema1URI(resource: string): string | undefined {
 }
 
 function onRequestSchemaURIThrowError(resource: string): string | undefined {
-	throw new Error('test what happens when an error is trhown and not caught');
+	throw new Error('test what happens when an error is thrown and not caught');
 }
 
 function onRequestSchemaContentThrowError(schemaUri: string): string | undefined {
-	throw new Error('test what happens when an error is trhown and not caught');
+	throw new Error('test what happens when an error is thrown and not caught');
 }
 
 function onRequestSchema1Content(schemaUri: string): string | undefined {


### PR DESCRIPTION
in case, one of the registered is throwing an error, it avoids to break
the other registered ones.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>