### PR TITLE
Use an output channel

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,7 +25,7 @@ namespace DynamicCustomSchemaRequestRegistration {
 	export const type: NotificationType<{}, {}> = new NotificationType('yaml/registerCustomSchemaRequest');
 }
 
-let outputChannel: OutputChannel;
+let client: LanguageClient;
 
 export function activate(context: ExtensionContext) {
 	// The YAML language server is implemented in node
@@ -59,7 +59,7 @@ export function activate(context: ExtensionContext) {
 	};
 
 	// Create the language client and start it
-	let client = new LanguageClient('yaml', 'YAML Support', serverOptions, clientOptions);
+	client = new LanguageClient('yaml', 'YAML Support', serverOptions, clientOptions);
 	let disposable = client.start();
 
 	const schemaExtensionAPI = new SchemaExtensionAPI(client);
@@ -135,8 +135,5 @@ function getSchemaAssociation(context: ExtensionContext): ISchemaAssociations {
 }
 
 export function logToExtensionOutputChannel(message: string) {
-	if(outputChannel === undefined){
-		outputChannel = window.createOutputChannel('VS Code Yaml extension');
-	}
-	outputChannel.appendLine(message);
+	client.outputChannel.appendLine(message);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@
 
 import * as path from 'path';
 
-import { workspace, ExtensionContext, extensions } from 'vscode';
+import { workspace, ExtensionContext, extensions, OutputChannel, window } from 'vscode';
 import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind, NotificationType } from 'vscode-languageclient';
 import { URI } from 'vscode-uri';
 import { CUSTOM_SCHEMA_REQUEST, CUSTOM_CONTENT_REQUEST, SchemaExtensionAPI } from './schema-extension-api';
@@ -24,6 +24,8 @@ namespace SchemaAssociationNotification {
 namespace DynamicCustomSchemaRequestRegistration {
 	export const type: NotificationType<{}, {}> = new NotificationType('yaml/registerCustomSchemaRequest');
 }
+
+let outputChannel: OutputChannel;
 
 export function activate(context: ExtensionContext) {
 	// The YAML language server is implemented in node
@@ -130,4 +132,11 @@ function getSchemaAssociation(context: ExtensionContext): ISchemaAssociations {
 	});
 
 	return associations;
+}
+
+export function logToExtensionOutputChannel(message: string) {
+	if(outputChannel === undefined){
+		outputChannel = window.createOutputChannel('VS Code Yaml extension');
+	}
+	outputChannel.appendLine(message);
 }

--- a/src/schema-extension-api.ts
+++ b/src/schema-extension-api.ts
@@ -1,6 +1,7 @@
 import { URI } from 'vscode-uri'
 import { LanguageClient, RequestType } from 'vscode-languageclient';
 import { workspace } from 'vscode';
+import { logToExtensionOutputChannel } from './extension';
 
 interface SchemaContributorProvider {
 	readonly requestSchema: (resource: string) => string;
@@ -113,7 +114,7 @@ class SchemaExtensionAPI implements ExtensionAPI {
 					matches.push(uri);
 				}
 			} catch (error) {
-				console.log(`Error thrown while requesting schema ` + error);
+				logToExtensionOutputChannel(`Error thrown while requesting schema "${error}" when calling the registered contributor "${customKey}"`);
 			}
 		}
 		return matches;


### PR DESCRIPTION
for instance, currently with VS Code Kubernetes extension which is throwing error with ```- ``` file content:
![Screenshot from 2020-07-23 10-42-45](https://user-images.githubusercontent.com/1105127/88267631-61d80680-ccd1-11ea-9fee-8ab7a816af14.png)

requires https://github.com/redhat-developer/vscode-yaml/pull/324