### PR TITLE
Allow array for fileMatch in yamlValidation contribution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1917,9 +1917,9 @@
       }
     },
     "vscode-json-languageservice": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-3.9.0.tgz",
-      "integrity": "sha512-J+2rbntYRLNL9wk0D2iovWo1df3JwYM+5VvWl1omNUgw+XbgpNBwpFZ/TsC1pTCdmpu5RMatXooplXZ8l/Irsg==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-3.10.0.tgz",
+      "integrity": "sha512-8IvuRSQnjznu+obqy6Dy4S4H68Ke7a3Kb+A0FcdctyAMAWEnrORpCpMOMqEYiPLm/OTYLVWJ7ql3qToDTozu4w==",
       "requires": {
         "jsonc-parser": "^2.3.1",
         "vscode-languageserver-textdocument": "^1.0.1",
@@ -2129,15 +2129,10 @@
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
     },
-    "yaml-ast-parser-custom-tags": {
-      "version": "0.0.43",
-      "resolved": "https://registry.npmjs.org/yaml-ast-parser-custom-tags/-/yaml-ast-parser-custom-tags-0.0.43.tgz",
-      "integrity": "sha512-R5063FF/JSAN6qXCmylwjt9PcDH6M0ExEme/nJBzLspc6FJDmHHIqM7xh2WfEmsTJqClF79A9VkXjkAqmZw9SQ=="
-    },
     "yaml-language-server": {
-      "version": "0.11.2-9738eda.0",
-      "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-0.11.2-9738eda.0.tgz",
-      "integrity": "sha512-BMBqvpWvGMzqxTknHGKKAZGK984HenYYQ/j0rh4/PZjRF/04t9NgmJ8N9h9sPYT4PoXXM+xZKbxQXtKvjmhUIg==",
+      "version": "0.12.1-5c483ee.0",
+      "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-0.12.1-5c483ee.0.tgz",
+      "integrity": "sha512-aaHxnrU+RDZBtvMk8vCeBoHZTCBqV/mKTEKP7U1qgR1GYOF3Y4ofC8DsRGnIuW6Rwyqymyscrsvj1tf8zmEr3Q==",
       "requires": {
         "js-yaml": "^3.13.1",
         "jsonc-parser": "^2.2.1",
@@ -2148,7 +2143,7 @@
         "vscode-languageserver-types": "^3.15.1",
         "vscode-nls": "^4.1.2",
         "vscode-uri": "^2.1.1",
-        "yaml-ast-parser-custom-tags": "0.0.43"
+        "yaml-language-server-parser": "^0.1.2-eb3160b.0"
       },
       "dependencies": {
         "vscode-nls": {
@@ -2162,6 +2157,11 @@
           "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
         }
       }
+    },
+    "yaml-language-server-parser": {
+      "version": "0.1.2-eb3160b.0",
+      "resolved": "https://registry.npmjs.org/yaml-language-server-parser/-/yaml-language-server-parser-0.1.2-eb3160b.0.tgz",
+      "integrity": "sha512-V0kBYtLCRg1vZi2kEcHvVZG0qYdh5L20eLBxVHS3TzFU4BvFmU8NkEhUq/Fdm9I/ckbEN8IWJQir1S0Z7ZPSPg=="
     },
     "yargs": {
       "version": "13.3.2",

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { Uri } from 'vscode';
+
+const Dot = '.'.charCodeAt(0);
+
+export function normalizePath(parts: string[]): string {
+  const newParts: string[] = [];
+  for (const part of parts) {
+    if (part.length === 0 || (part.length === 1 && part.charCodeAt(0) === Dot)) {
+      // ignore
+    } else if (part.length === 2 && part.charCodeAt(0) === Dot && part.charCodeAt(1) === Dot) {
+      newParts.pop();
+    } else {
+      newParts.push(part);
+    }
+  }
+  if (parts.length > 1 && parts[parts.length - 1].length === 0) {
+    newParts.push('');
+  }
+  let res = newParts.join('/');
+  if (parts[0].length === 0) {
+    res = '/' + res;
+  }
+  return res;
+}
+
+export function joinPath(uri: Uri, ...paths: string[]): Uri {
+  const parts = uri.path.split('/');
+  for (const path of paths) {
+    parts.push(...path.split('/'));
+  }
+  return uri.with({ path: normalizePath(parts) });
+}


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR is the client side part of https://github.com/redhat-developer/vscode-yaml/issues/387. Majority of it was taken from vscode-json-languageserver with minor modifications

### What issues does this PR fix or reference?
https://github.com/redhat-developer/vscode-yaml/issues/387

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Add in:
```
"yamlValidation": [
      {
        "fileMatch": ["test.yml", "test.yaml"],
        "url": "https://gist.githubusercontent.com/JPinkney/fbbb95f3708e8b33f81267b243981ff6/raw/09af433aff3972f5d72cfe5c69951e94c1497875/kubernetes-console.json"
      }
]
```
under the "contributes" section of the package.json, then test the extension and make sure that the kubernetes schema is used for both test.yml and test.yaml (it might take a few seconds to load because the schema is so big)