### PR TITLE
Add in non-standard lsp request for resolving schemas on the client-side

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1590,13 +1590,13 @@
       "dev": true
     },
     "request-light": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.2.5.tgz",
-      "integrity": "sha512-eBEh+GzJAftUnex6tcL6eV2JCifY0+sZMIUpUPOVXbs2nV5hla4ZMmO3icYKGuGVuQ2zHE9evh4OrRcH4iyYYw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.4.0.tgz",
+      "integrity": "sha512-fimzjIVw506FBZLspTAXHdpvgvQebyjpNyLRd0e6drPPRq7gcrROeGWRyF81wLqFg5ijPgnOQbmfck5wdTqpSA==",
       "requires": {
         "http-proxy-agent": "^2.1.0",
-        "https-proxy-agent": "^2.2.3",
-        "vscode-nls": "^4.1.1"
+        "https-proxy-agent": "^2.2.4",
+        "vscode-nls": "^4.1.2"
       },
       "dependencies": {
         "vscode-nls": {
@@ -2130,15 +2130,15 @@
       "dev": true
     },
     "yaml-language-server": {
-      "version": "0.12.1-5c483ee.0",
-      "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-0.12.1-5c483ee.0.tgz",
-      "integrity": "sha512-aaHxnrU+RDZBtvMk8vCeBoHZTCBqV/mKTEKP7U1qgR1GYOF3Y4ofC8DsRGnIuW6Rwyqymyscrsvj1tf8zmEr3Q==",
+      "version": "0.13.1-33b090a.0",
+      "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-0.13.1-33b090a.0.tgz",
+      "integrity": "sha512-4hNSDsdt9BVAM+tHshBaikVXnN4ZR8zaNcNpmYpAYkZ1MdAz6w4zPZUCVCkfmQ5tUKvIgiXtDkITShOJ32lqhw==",
       "requires": {
         "js-yaml": "^3.13.1",
         "jsonc-parser": "^2.2.1",
         "prettier": "2.0.5",
         "request-light": "^0.2.4",
-        "vscode-json-languageservice": "^3.6.0",
+        "vscode-json-languageservice": "^3.10.0",
         "vscode-languageserver": "^5.2.1",
         "vscode-languageserver-types": "^3.15.1",
         "vscode-nls": "^4.1.2",
@@ -2146,6 +2146,16 @@
         "yaml-language-server-parser": "^0.1.2-eb3160b.0"
       },
       "dependencies": {
+        "request-light": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.2.5.tgz",
+          "integrity": "sha512-eBEh+GzJAftUnex6tcL6eV2JCifY0+sZMIUpUPOVXbs2nV5hla4ZMmO3icYKGuGVuQ2zHE9evh4OrRcH4iyYYw==",
+          "requires": {
+            "http-proxy-agent": "^2.1.0",
+            "https-proxy-agent": "^2.2.3",
+            "vscode-nls": "^4.1.1"
+          }
+        },
         "vscode-nls": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
     "vscode-test": "^1.4.0"
   },
   "dependencies": {
+    "request-light": "^0.4.0",
     "vscode-languageclient": "5.2.1",
     "vscode-nls": "^3.2.1",
     "vscode-uri": "^2.0.3",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,9 +39,9 @@ namespace SchemaAssociationNotification {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
-namespace ContentRequestRegistration {
+namespace VSCodeContentRequestRegistration {
   // eslint-disable-next-line @typescript-eslint/ban-types
-  export const type: NotificationType<{}, {}> = new NotificationType('yaml/registerContentRequest');
+  export const type: NotificationType<{}, {}> = new NotificationType('yaml/registerVSCodeContentRequest');
 }
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -107,7 +107,7 @@ export function activate(context: ExtensionContext): SchemaExtensionAPI {
     // Tell the server that the client is ready to provide custom schema content
     client.sendNotification(DynamicCustomSchemaRequestRegistration.type);
     // Tell the server that the client supports schema requests sent directly to it
-    client.sendNotification(ContentRequestRegistration.type);
+    client.sendNotification(VSCodeContentRequestRegistration.type);
     // If the server asks for custom schema content, get it and send it back
     client.onRequest(CUSTOM_SCHEMA_REQUEST, (resource: string) => {
       return schemaExtensionAPI.requestCustomSchema(resource);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,9 +9,17 @@
 import * as path from 'path';
 
 import { workspace, ExtensionContext, extensions } from 'vscode';
-import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind, NotificationType } from 'vscode-languageclient';
+import {
+  LanguageClient,
+  LanguageClientOptions,
+  ServerOptions,
+  TransportKind,
+  NotificationType,
+  RequestType,
+} from 'vscode-languageclient';
 import { CUSTOM_SCHEMA_REQUEST, CUSTOM_CONTENT_REQUEST, SchemaExtensionAPI } from './schema-extension-api';
 import { joinPath } from './paths';
+import { xhr, configure as configureHttpRequests, getErrorStatusDescription, XHRResponse } from 'request-light';
 
 export interface ISchemaAssociations {
   [pattern: string]: string[];
@@ -28,6 +36,18 @@ namespace SchemaAssociationNotification {
   export const type: NotificationType<ISchemaAssociations | ISchemaAssociation[], any> = new NotificationType(
     'json/schemaAssociations'
   );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+namespace ContentRequestRegistration {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  export const type: NotificationType<{}, {}> = new NotificationType('yaml/registerContentRequest');
+}
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+namespace VSCodeContentRequest {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export const type: RequestType<string, string, any, any> = new RequestType('vscode/content');
 }
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -86,12 +106,28 @@ export function activate(context: ExtensionContext): SchemaExtensionAPI {
     });
     // Tell the server that the client is ready to provide custom schema content
     client.sendNotification(DynamicCustomSchemaRequestRegistration.type);
+    // Tell the server that the client supports schema requests sent directly to it
+    client.sendNotification(ContentRequestRegistration.type);
     // If the server asks for custom schema content, get it and send it back
     client.onRequest(CUSTOM_SCHEMA_REQUEST, (resource: string) => {
       return schemaExtensionAPI.requestCustomSchema(resource);
     });
     client.onRequest(CUSTOM_CONTENT_REQUEST, (uri: string) => {
       return schemaExtensionAPI.requestCustomSchemaContent(uri);
+    });
+    client.onRequest(VSCodeContentRequest.type, (uri: string) => {
+      const httpSettings = workspace.getConfiguration('http');
+      configureHttpRequests(httpSettings.http && httpSettings.http.proxy, httpSettings.http && httpSettings.http.proxyStrictSSL);
+
+      const headers = { 'Accept-Encoding': 'gzip, deflate' };
+      return xhr({ url: uri, followRedirects: 5, headers }).then(
+        (response) => {
+          return response.responseText;
+        },
+        (error: XHRResponse) => {
+          return Promise.reject(error.responseText || getErrorStatusDescription(error.status) || error.toString());
+        }
+      );
     });
   });
 


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR is the client-side request to https://github.com/redhat-developer/yaml-language-server/pull/359. The client-side handles the schema downloading and sending the information back to the yaml language server

### What issues does this PR fix or reference?
https://github.com/redhat-developer/vscode-yaml/issues/107

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
The only way I know how to test this is on the Red Hat VPN.

You'll need the server side changes: https://github.com/redhat-developer/yaml-language-server/pull/359

Once you connect to the VPN these schemas should resolve correctly
```
"yaml.schemas": {
    "https://gitlab.cee.redhat.com/cpaas/service/-/raw/development/resources/schemas/release-root.json": "release.yml",
    "https://gitlab.cee.redhat.com/cpaas/service/-/raw/development/resources/schemas/product-root.json": "product.yml"
  }
```