### PR TITLE
Set 'nodejs-12.20.0' for Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 def installBuildRequirements(){
-	def nodeHome = tool 'nodejs-12.18.3'
+	def nodeHome = tool 'nodejs-12.20.0'
 	env.PATH="${env.PATH}:${nodeHome}/bin"
 	sh "npm install -g typescript"
 	sh "npm install -g vsce"


### PR DESCRIPTION
### What does this PR do?
Change Node.JS version for Jenkins build.
We use Jenkins to perform release.
