### PR TITLE
Allow other VSCode Extensions to register bundles

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,0 +1,7 @@
+
+export namespace Commands {
+  /**
+   * Execute Workspace Command
+   */
+  export const EXECUTE_WORKSPACE_COMMAND = 'yaml.execute.workspaceCommand';
+}


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR is a P.O.C that allows other VSCode extensions to register bundles (similar to vscode-java/jdt.ls bundles) through a "yamlExtensions" contribution.

Server-side: https://github.com/redhat-developer/yaml-language-server/pull/369

### What issues does this PR fix or reference?
https://github.com/redhat-developer/vscode-yaml/issues/402

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
