### PR TITLE
Implement a way to determine if an extension is conflicting with VSCo…

### DIFF
--- a/src/extensionConflicts.ts
+++ b/src/extensionConflicts.ts
@@ -6,7 +6,7 @@ import { commands, Extension, extensions, window } from 'vscode';
 
 // A set of VSCode extension ID's that conflict with VSCode-YAML
 const azureDeploy = 'ms-vscode-deploy-azure.azure-deploy';
-const conflictingIDs = new Set(['vscoss.vscode-ansible', azureDeploy]);
+const conflictingIDs = new Set(['vscoss.vscode-ansible', azureDeploy, 'sysninja.vscode-ansible-mod', 'haaaad.ansible']);
 
 // A set of VSCode extension ID's that are currently uninstalling
 const uninstallingIDs = new Set();

--- a/src/extensionConflicts.ts
+++ b/src/extensionConflicts.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved..
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { commands, Extension, extensions, window } from 'vscode';
+
+// A set of VSCode extension ID's that conflict with VSCode-YAML
+const conflictingIDs = new Set(['vscoss.vscode-ansible', 'ms-vscode-deploy-azure.azure-deploy']);
+
+/**
+ * Get all of the installed extensions that currently conflict with VSCode-YAML
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getConflictingExtensions(): Extension<any>[] {
+  const conflictingExtensions = [];
+  conflictingIDs.forEach((extension) => {
+    const ext = extensions.getExtension(extension);
+    if (ext) {
+      conflictingExtensions.push(ext);
+    }
+  });
+  return conflictingExtensions;
+}
+
+/**
+ * Display the uninstall conflicting extension notification if there are any conflicting extensions currently installed
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function showUninstallConflictsNotification(conflictingExts: Extension<any>[]): void {
+  const uninstallMsg = 'Uninstall';
+
+  // Gather all the conflicting display names
+  let conflictMsg = '';
+  if (conflictingExts.length === 1) {
+    conflictMsg = `${conflictingExts[0].packageJSON.displayName} extension is incompatible with VSCode-YAML. Please uninstall it.`;
+  } else {
+    const extNames = [];
+    conflictingExts.forEach((ext) => {
+      extNames.push(ext.packageJSON.displayName);
+    });
+    conflictMsg = `The ${extNames.join(', ')} extensions are incompatible with VSCode-YAML. Please uninstall them.`;
+  }
+
+  window.showInformationMessage(conflictMsg, uninstallMsg).then((clickedMsg) => {
+    if (clickedMsg === uninstallMsg) {
+      conflictingExts.forEach((ext) => {
+        commands.executeCommand('workbench.extensions.uninstallExtension', ext.id);
+      });
+    }
+  });
+}


### PR DESCRIPTION
Implement a way to determine if an extension is conflicting with VSCode-YAML

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR makes it so that a notification will pop up prompting a user to uninstall conflicting extensions with VSCode-YAML

### What issues does this PR fix or reference?
https://github.com/redhat-developer/vscode-yaml/issues/404

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Launch extension with Ansible already installed -> you should see notification saying to uninstall -> click it and it should be uninstalled (though manual reload is required)

Launch extension without Ansible installed -> install Ansible -> you should see notification saying to uninstall -> click it and it should be uninstalled (though manual reload is required)
