### PR TITLE
Publish artifacts to correct location

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ node('rhel8'){
 
 	stage 'Upload vscode-yaml to staging'
 	def vsix = findFiles(glob: '**.vsix')
-	sh "rsync -Pzrlt --rsh=ssh --protocol=28 ${vsix[0].path} ${UPLOAD_LOCATION}"
+	sh "rsync -Pzrlt --rsh=ssh --protocol=28 ${vsix[0].path} ${UPLOAD_LOCATION}/snapshots/vscode-yaml/"
 	stash name:'vsix', includes:vsix[0].path
 }
 
@@ -61,5 +61,9 @@ node('rhel8'){
 	  	sh 'ovsx publish -p ${OVSX_TOKEN}' + " ${vsix[0].path}"
 	  }
 	  archive includes:"**.vsix"
+
+	  stage ("Promote the build to stable") {
+		sh "rsync -Pzrlt --rsh=ssh --protocol=28 *.vsix* ${UPLOAD_LOCATION}/stable/vscode-yaml/"
+	  }
   }
 }


### PR DESCRIPTION


Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
Fixes an issue where artifacts are published into the wrong folder:
`vscode-yaml staging` is now pushed to /snapshots/vscode-yaml
`vscode-yaml stable` is now pushed to /stable/vscode-yaml

### What issues does this PR fix or reference?
https://github.com/redhat-developer/vscode-yaml/issues

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
