### PR TITLE
Fix runtime warning on configuration loading

### DIFF
--- a/test/helper.ts
+++ b/test/helper.ts
@@ -44,12 +44,12 @@ export const getDocUri = (p: string): vscode.Uri => {
 };
 
 export const updateSettings = (setting: string, value: unknown): Thenable<void> => {
-  const yamlConfiguration = vscode.workspace.getConfiguration('yaml');
+  const yamlConfiguration = vscode.workspace.getConfiguration('yaml', null);
   return yamlConfiguration.update(setting, value, false);
 };
 
 export const resetSettings = (setting: string, value: unknown): Thenable<void> => {
-  const yamlConfiguration = vscode.workspace.getConfiguration('yaml');
+  const yamlConfiguration = vscode.workspace.getConfiguration('yaml', null);
   return yamlConfiguration.update(setting, value, false);
 };
 


### PR DESCRIPTION
Avoid an warning message as:

[exthost] [warning] [redhat.vscode-yaml] Accessing a resource scoped configuration without providing a resource is not expected. To get the effective value for '[yaml]', provide the URI of a resource or 'null' for any resource.
