### PR TITLE
Load schema content contributed by other extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,12 @@ The following settings are supported:
 - `yaml.schemas`: Helps you associate schemas with files in a glob pattern
 - `yaml.schemaStore.enable`: When set to true the YAML language server will pull in all available schemas from [JSON Schema Store](http://schemastore.org/json/)
 - `yaml.customTags`: Array of custom tags that the parser will validate against. It has two ways to be used. Either an item in the array is a custom tag such as "!Ref" and it will automatically map !Ref to scalar or you can specify the type of the object !Ref should be e.g. "!Ref sequence". The type of object can be either scalar (for strings and booleans), sequence (for arrays), mapping (for objects).
-- `[yaml]`: VSCode-YAML adds default configuration for all yaml files. More specifically it converts tabs to spaces to ensure valid yaml, sets the tab size, and allows live typing autocompletion and formatting. These settings can be modified via the corresponding settings inside the `[yaml]` section in the settings:
+- `[yaml]`: VSCode-YAML adds default configuration for all yaml files. More specifically it converts tabs to spaces to ensure valid yaml, sets the tab size, and allows live typing autocompletion and formatting, also allows code lens. These settings can be modified via the corresponding settings inside the `[yaml]` section in the settings:
   - `editor.insertSpaces`
   - `editor.tabSize`
   - `editor.quickSuggestions`
   - `editor.formatOnType`
+  - `editor.codeLens`
 
 ##### Adding custom tags
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -102,7 +102,10 @@ export function activate(context: ExtensionContext): SchemaExtensionAPI {
   // client can be deactivated on extension deactivation
   context.subscriptions.push(disposable);
   context.subscriptions.push(
-    workspace.registerTextDocumentContentProvider('json-schema', new JSONSchemaDocumentContentProvider(schemaCache))
+    workspace.registerTextDocumentContentProvider(
+      'json-schema',
+      new JSONSchemaDocumentContentProvider(schemaCache, schemaExtensionAPI)
+    )
   );
 
   findConflicts();

--- a/src/json-schema-content-provider.ts
+++ b/src/json-schema-content-provider.ts
@@ -14,7 +14,8 @@ export class JSONSchemaDocumentContentProvider implements TextDocumentContentPro
     if (uri.fragment) {
       const origUri = uri.fragment;
       const schemaUri = Uri.parse(origUri);
-      if (origUri.startsWith('https') || origUri.startsWith('http')) {
+      // handle both 'http' and 'https'
+      if (origUri.startsWith('http')) {
         return getJsonSchemaContent(origUri, this.schemaCache);
       } else if (this.schemaApi.hasProvider(schemaUri.scheme)) {
         let content = this.schemaApi.requestCustomSchemaContent(origUri);

--- a/src/schema-extension-api.ts
+++ b/src/schema-extension-api.ts
@@ -5,7 +5,7 @@ import { logToExtensionOutputChannel } from './extension';
 
 interface SchemaContributorProvider {
   readonly requestSchema: (resource: string) => string;
-  readonly requestSchemaContent: (uri: string) => string;
+  readonly requestSchemaContent: (uri: string) => Promise<string> | string;
   readonly label?: string;
 }
 
@@ -137,7 +137,7 @@ class SchemaExtensionAPI implements ExtensionAPI {
    * @param {string} uri the schema uri returned from requestSchema.
    * @returns {string} the schema content
    */
-  public requestCustomSchemaContent(uri: string): string {
+  public requestCustomSchemaContent(uri: string): Promise<string> | string {
     if (uri) {
       const _uri = URI.parse(uri);
 
@@ -153,6 +153,10 @@ class SchemaExtensionAPI implements ExtensionAPI {
 
   public async modifySchemaContent(schemaModifications: SchemaAdditions | SchemaDeletions): Promise<void> {
     return this._yamlClient.sendRequest(SchemaModificationNotification.type, schemaModifications);
+  }
+
+  public hasProvider(schema: string): boolean {
+    return this._customSchemaContributors[schema] !== undefined;
   }
 }
 

--- a/test/json-shema-content-provider.test.ts
+++ b/test/json-shema-content-provider.test.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import * as vscode from 'vscode';
+import { getDocUri, activate } from './helper';
+import * as assert from 'assert';
+
+describe('Tests for JSON Schema content provider', () => {
+  const SCHEMA = 'myschema';
+  const schemaJSON = JSON.stringify({
+    type: 'object',
+    properties: {
+      version: {
+        type: 'string',
+        description: 'A stringy string string',
+        enum: ['test'],
+      },
+    },
+  });
+
+  function onRequestSchema1URI(resource: string): string | undefined {
+    if (resource.endsWith('completion.yaml') || resource.endsWith('basic.yaml')) {
+      return `${SCHEMA}://schema/porter`;
+    }
+    return undefined;
+  }
+
+  function onRequestSchema1Content(): string | undefined {
+    return schemaJSON;
+  }
+
+  it('should handle "json-schema" url', async () => {
+    const docUri = getDocUri('completion/completion.yaml');
+    const client = await activate(docUri);
+    client._customSchemaContributors = {};
+    client.registerContributor(SCHEMA, onRequestSchema1URI, onRequestSchema1Content);
+    const customUri = vscode.Uri.parse(`json-schema://some/url/schema.json#${SCHEMA}://some/path/schema.json`);
+    const doc = await vscode.workspace.openTextDocument(customUri);
+    const editor = await vscode.window.showTextDocument(doc);
+    assert.strictEqual(editor.document.getText(), JSON.stringify(JSON.parse(schemaJSON), null, 2));
+    client._customSchemaContributors = {};
+  });
+});


### PR DESCRIPTION
### What does this PR do?
Add ability to open JSON Schema content contributed by other extensions with ExtensionAPI.

Depends on https://github.com/redhat-developer/yaml-language-server/pull/424

### What issues does this PR fix or reference?
https://github.com/redhat-developer/yaml-language-server/issues/412

### Is it tested? How?
With test. To manual test, open any yaml which has json schema contributed with ExtensionAPI(any k8s yaml with k8s extension installed) and click on codelens over first line, it should open JSON Schema in editor tab.
