### PR TITLE
Fix returning undefined from cache

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,10 +90,10 @@ export function activate(context: ExtensionContext): SchemaExtensionAPI {
     revealOutputChannelOn: RevealOutputChannelOn.Never,
   };
 
-  const schemaCache = new JSONSchemaCache(context.globalStoragePath, context.globalState);
-
   // Create the language client and start it
   client = new LanguageClient('yaml', 'YAML Support', serverOptions, clientOptions);
+
+  const schemaCache = new JSONSchemaCache(context.globalStoragePath, context.globalState, client.outputChannel);
   const disposable = client.start();
 
   const schemaExtensionAPI = new SchemaExtensionAPI(client);

--- a/src/json-schema-content-provider.ts
+++ b/src/json-schema-content-provider.ts
@@ -59,7 +59,7 @@ export async function getJsonSchemaContent(uri: string, schemaCache: JSONSchemaC
     .then((text) => {
       return text;
     })
-    .catch((error: XHRResponse) => {
+    .catch(async (error: XHRResponse) => {
       // content not changed, return cached
       if (error.status === 304) {
         const content = await schemaCache.getSchema(uri);

--- a/src/json-schema-content-provider.ts
+++ b/src/json-schema-content-provider.ts
@@ -72,16 +72,19 @@ export async function getJsonSchemaContent(uri: string, schemaCache: JSONSchemaC
               return response.responseText;
             })
             .catch((err: XHRResponse) => {
-              return creteReject(err);
+              return createReject(err);
             });
         }
         return content;
       }
       // in case of some error, like internet connection issue, check if cached version exist and return it
       if (schemaCache.getETag(uri)) {
-        return schemaCache.getSchema(uri);
+        const content = schemaCache.getSchema(uri);
+        if (content) {
+          return content;
+        }
       }
-      return creteReject(error);
+      return createReject(error);
     });
 }
 

--- a/src/json-schema-content-provider.ts
+++ b/src/json-schema-content-provider.ts
@@ -85,6 +85,6 @@ export async function getJsonSchemaContent(uri: string, schemaCache: JSONSchemaC
     });
 }
 
-function creteReject(error: XHRResponse): Promise<string> {
+function createReject(error: XHRResponse): Promise<string> {
   return Promise.reject(error.responseText || getErrorStatusDescription(error.status) || error.toString());
 }

--- a/src/json-schema-content-provider.ts
+++ b/src/json-schema-content-provider.ts
@@ -62,7 +62,7 @@ export async function getJsonSchemaContent(uri: string, schemaCache: JSONSchemaC
     .catch((error: XHRResponse) => {
       // content not changed, return cached
       if (error.status === 304) {
-        const content = schemaCache.getSchema(uri);
+        const content = await schemaCache.getSchema(uri);
         // ensure that we return content even if cache doesn't have it
         if (content === undefined) {
           console.error(`Cannot read cached content for: ${uri}, trying to load again`);


### PR DESCRIPTION
### What does this PR do?
Trying to fix return undefined from schema cache.
I cannot reproduce #462 on my laptop, it seems that it is can be related to OS and file system.
This PR ensures that if we receive 304 HTTP status whe check JSON Schema content and for some reasons cache doesn't contains content, we just load again it from server.

### What issues does this PR fix or reference?
#462 

### Is it tested? How?
Manually on Mac. It would be nice if reviews can test it on other systems.
Just open any yaml files with schema from schema store associated with it, and make sure that schema loaded.
