### PR TITLE
Change GH Action badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![CI](https://github.com/redhat-developer/vscode-yaml/actions/workflows/CI.yaml/badge.svg)](https://github.com/redhat-developer/vscode-yaml/actions/workflows/CI.yaml)[![Marketplace Version](https://vsmarketplacebadge.apphb.com/version/redhat.vscode-yaml.svg 'Current Release')](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)
+[![CI](https://github.com/redhat-developer/vscode-yaml/workflows/CI/badge.svg)](https://github.com/redhat-developer/vscode-yaml/actions/workflows/CI.yaml)
+[![Marketplace Version](https://vsmarketplacebadge.apphb.com/version/redhat.vscode-yaml.svg 'Current Release')](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)
 
 # YAML Language Support by Red Hat
 Provides comprehensive YAML Language support to [Visual Studio Code](https://code.visualstudio.com/), via the [yaml-language-server](https://github.com/redhat-developer/yaml-language-server), with built-in Kubernetes syntax support.


### PR DESCRIPTION
### What does this PR do?
Just change GH Action badge to old one as current is not supported in `vsce` tool and release build failing with message:
```
 ERROR  SVGs are restricted in README.md; please use other file image formats, such as PNG: https://github.com/redhat-developer/vscode-yaml/actions/workflows/CI.yaml/badge.svg
```
It seems that GH changes URL for badges and new URL is not supported in `vsce`, [details]( https://github.com/microsoft/vscode-vsce/issues/553)
