### PR TITLE
feat(prettier): Support doNotIndent and commentSpacesFromContent

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ The following settings are supported:
 * `yaml.format.bracketSpacing`: Print spaces between brackets in objects
 * `yaml.format.proseWrap`: Always: wrap prose if it exeeds the print width, Never: never wrap the prose, Preserve: wrap prose as-is
 * `yaml.format.printWidth`: Specify the line length that the printer will wrap on
+* `yaml.format.doNotIndent`: Enabled do-not-indent style for sequence in mapping
+* `yaml.format.commentSpacesFromContent`: Specify the amount of spaces before content and trailing comments on line
 * `yaml.validate`: Enable/disable validation feature
 * `yaml.hover`: Enable/disable hover
 * `yaml.completion`: Enable/disable autocompletion

--- a/package.json
+++ b/package.json
@@ -119,6 +119,16 @@
           "default": 80,
           "description": "Specify the line length that the printer will wrap on"
         },
+        "yaml.format.doNotIndent": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enabled do-not-indent style for sequence in mapping"
+        },
+        "yaml.format.commentSpacesFromContent": {
+          "type": "integer",
+          "default": 1,
+          "description": "Specify the amount of spaces before content and trailing comments on line"
+        },
         "yaml.validate": {
           "type": "boolean",
           "default": true,
@@ -201,7 +211,7 @@
     "eslint-plugin-prettier": "^3.1.4",
     "glob": "^7.1.6",
     "mocha": "^8.0.1",
-    "prettier": "^2.0.5",
+    "prettier": "^2.4.0",
     "rimraf": "^3.0.2",
     "sinon": "^9.0.3",
     "sinon-chai": "^3.5.0",


### PR DESCRIPTION
### What does this PR do?
Allows users to configure `do-not-indent` style and set the amount of spaces between content and trailing comments making this extension to comply with default settings of yamllint linter.

### What issues does this PR fix or reference?
Resolves: 
- https://github.com/redhat-developer/vscode-yaml/issues/433
- https://github.com/redhat-developer/vscode-yaml/issues/172

Depends on:
- https://github.com/prettier/prettier/pull/10927 (requires new Prettier release)
- https://github.com/prettier/prettier/pull/10926 (requires new Prettier release)
- (required yaml-language-server-release)


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
