### PR TITLE
Update vscode-redhat-telemetry to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,7 +216,7 @@
     "vscode-test": "^1.4.0"
   },
   "dependencies": {
-    "@redhat-developer/vscode-redhat-telemetry": "0.1.1",
+    "@redhat-developer/vscode-redhat-telemetry": "0.2.0",
     "fs-extra": "^9.1.0",
     "request-light": "^0.4.0",
     "vscode-languageclient": "7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,10 +59,10 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@redhat-developer/vscode-redhat-telemetry@0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@redhat-developer/vscode-redhat-telemetry/-/vscode-redhat-telemetry-0.1.1.tgz#ddf7fff968274d558caed56c1ea3d9454bd15ee8"
-  integrity sha512-uMJNiFNUXCYy/4KZaX+Ctueq+KXIWyS5Cfv2wqHNNzpV9+EhPLHUJoZKbCMY/P+IlgqTWYfpDkghZHiq5ChvEA==
+"@redhat-developer/vscode-redhat-telemetry@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@redhat-developer/vscode-redhat-telemetry/-/vscode-redhat-telemetry-0.2.0.tgz#16aa424e9603c0402d2be82a4d9748ba2240a92a"
+  integrity sha512-qS9p+iXpdMwCzhVRr/Ft5dMQQXB+6CxBRnpp3NDUuxYP1s/K/B1dPlIW5lKncjPUwYaKvPbpMgGGDmsosOzT8A==
   dependencies:
     "@types/analytics-node" "^3.1.4"
     analytics-node "^3.5.0"


### PR DESCRIPTION
### What does this PR do?
Update vscode-redhat-telemetry to 0.2.0
This allows using vscode-yaml in clients with vscode API < 1.55

### What issues does this PR fix or reference?
Fixes #537

### Is it tested? How?
Install vsix in vscode 1.54, check #537 is fixed