### PR TITLE
Improve telemetry

### DIFF
--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -88,7 +88,7 @@ export class TelemetryOutputChannel implements vscode.OutputChannel {
 
   private createErrorMessage(value: string): string {
     if (value.startsWith('[Error')) {
-      value = value.substr(0, value.indexOf(']')).trim();
+      value = value.substr(value.indexOf(']'), value.length).trim();
     }
 
     return value;

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -78,17 +78,17 @@ export class TelemetryOutputChannel implements vscode.OutputChannel {
       } else {
         const starts = value.startsWith(skip.text);
         if (starts) {
-          return false;
+          return true;
         }
       }
     }
 
-    return true;
+    return false;
   }
 
   private createErrorMessage(value: string): string {
     if (value.startsWith('[Error')) {
-      value = value.substr(value.indexOf(']'), value.length).trim();
+      value = value.substr(value.indexOf(']') + 1, value.length).trim();
     }
 
     return value;

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -84,8 +84,8 @@ describe('Telemetry Test', () => {
     });
 
     it('should send telemetry if log error on "appendLine"', () => {
-      telemetryChannel.appendLine('[Error] Some');
-      expect(telemetry.send).calledOnceWith({ name: 'yaml.server.error', properties: { error: 'Some' } });
+      telemetryChannel.appendLine('[Error] Some error');
+      expect(telemetry.send).calledOnceWith({ name: 'yaml.server.error', properties: { error: 'Some error' } });
     });
 
     it("shouldn't send telemetry if error should be skipped", () => {

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -79,13 +79,20 @@ describe('Telemetry Test', () => {
     });
 
     it('should send telemetry if log error in "append"', () => {
-      telemetryChannel.append('[Error Some');
-      expect(telemetry.send).calledOnceWith({ name: 'yaml.server.error', properties: { error: '[Error Some' } });
+      telemetryChannel.append('[Error] Some');
+      expect(telemetry.send).calledOnceWith({ name: 'yaml.server.error', properties: { error: 'Some' } });
     });
 
     it('should send telemetry if log error on "appendLine"', () => {
-      telemetryChannel.appendLine('[Error Some');
-      expect(telemetry.send).calledOnceWith({ name: 'yaml.server.error', properties: { error: '[Error Some' } });
+      telemetryChannel.appendLine('[Error] Some');
+      expect(telemetry.send).calledOnceWith({ name: 'yaml.server.error', properties: { error: 'Some' } });
+    });
+
+    it("shouldn't send telemetry if error should be skipped", () => {
+      telemetryChannel.append(
+        "[Error - 15:10:33] (node:25052) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification."
+      );
+      expect(telemetry.send).not.called;
     });
   });
 


### PR DESCRIPTION
### What does this PR do?
Changes based on @fbricon feedback:

- Ignore `Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment ` message
- Remove `[Error - 2:04:53 PM]` from telemetry error message start

### What issues does this PR fix or reference?
none

### Is it tested? How?
with tests
