### PR TITLE
Do not log messages with 'null' text

### DIFF
--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -61,14 +61,18 @@ export class TelemetryOutputChannel implements vscode.OutputChannel {
   }
 
   private checkError(value: string): void {
-    if (!value || value === 'null') {
-      return; // ignore messages with 'null' text
+    if (!value) {
+      return;
     }
     if (value.startsWith('[Error') || value.startsWith('  Message: Request')) {
       if (this.isNeedToSkip(value)) {
         return;
       }
-      this.telemetry.send({ name: 'yaml.server.error', properties: { error: this.createErrorMessage(value) } });
+      const errorMessage = this.createErrorMessage(value);
+      if (errorMessage === 'null') {
+        return; // ignore messages with 'null' text
+      }
+      this.telemetry.send({ name: 'yaml.server.error', properties: { error: errorMessage } });
     }
   }
 
@@ -94,7 +98,7 @@ export class TelemetryOutputChannel implements vscode.OutputChannel {
       value = value.substr(value.indexOf(']') + 1, value.length).trim();
     }
 
-    return value;
+    return value.trim();
   }
 
   clear(): void {

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -61,6 +61,9 @@ export class TelemetryOutputChannel implements vscode.OutputChannel {
   }
 
   private checkError(value: string): void {
+    if (!value || value === 'null') {
+      return; // ignore messages with 'null' text
+    }
     if (value.startsWith('[Error') || value.startsWith('  Message: Request')) {
       if (this.isNeedToSkip(value)) {
         return;

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -94,6 +94,11 @@ describe('Telemetry Test', () => {
       );
       expect(telemetry.send).not.called;
     });
+
+    it("shouldn't send telemetry if message is 'null'", () => {
+      telemetryChannel.append('[Error - 15:10:33] null');
+      expect(telemetry.send).not.called;
+    });
   });
 
   describe('TelemetryErrorHandler', () => {


### PR DESCRIPTION
### What does this PR do?
Currently our telemetry service contains a lot errors with `null` text message, they not have any meaning, so we just ignore them. 

### What issues does this PR fix or reference?
none


