### PR TITLE
Update vscode-redhat-telemetry to 0.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,7 +222,7 @@
     "vscode-test": "^1.4.0"
   },
   "dependencies": {
-    "@redhat-developer/vscode-redhat-telemetry": "0.2.0",
+    "@redhat-developer/vscode-redhat-telemetry": "0.4.2",
     "fs-extra": "^9.1.0",
     "request-light": "^0.4.0",
     "vscode-languageclient": "7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,15 +59,16 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@redhat-developer/vscode-redhat-telemetry@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@redhat-developer/vscode-redhat-telemetry/-/vscode-redhat-telemetry-0.2.0.tgz#16aa424e9603c0402d2be82a4d9748ba2240a92a"
-  integrity sha512-qS9p+iXpdMwCzhVRr/Ft5dMQQXB+6CxBRnpp3NDUuxYP1s/K/B1dPlIW5lKncjPUwYaKvPbpMgGGDmsosOzT8A==
+"@redhat-developer/vscode-redhat-telemetry@0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@redhat-developer/vscode-redhat-telemetry/-/vscode-redhat-telemetry-0.4.2.tgz#fd9cf99c481ae353aa8f7eca4dc07fd99ac2a450"
+  integrity sha512-xHBRm7gpqDVgkUBWal5XnarJ+7FSwSqJL2UvUBbc5+NwsQIAeNROXwh9Mc6P7chii76Wdbw+khW+BTHXxir7og==
   dependencies:
     "@types/analytics-node" "^3.1.4"
     analytics-node "^3.5.0"
-    countries-and-timezones "^2.3.1"
+    countries-and-timezones "2.4.0"
     getos "^3.2.1"
+    object-hash "^2.2.0"
     os-locale "^5.0.0"
     uuid "^8.3.2"
 
@@ -591,7 +592,7 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
-countries-and-timezones@^2.3.1:
+countries-and-timezones@2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/countries-and-timezones/-/countries-and-timezones-2.4.0.tgz#fd740c830679c5d8c635c6764b302f3650ca7144"
   integrity sha512-h6k9zgw99k8fjon5cO94k8Aslyj0fM+S4hfTyJ6sbSjyOO9lu5/wcOXLrhc1cGUoHCrnx56WYSNEasSKqSGlJw==
@@ -1535,6 +1536,11 @@ npm-run-path@^4.0.0:
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
+
+object-hash@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
+  integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
Signed-off-by: Fred Bricon <fbricon@gmail.com>

### What does this PR do?
Update vscode-redhat-telemetry to 0.4.2

### What issues does this PR fix or reference?
- reduces the amount of identify events sent to segment.com
- better identify unique users on gitpod

### Is it tested? How?
- when running in extension development host, the host debug console will display "vscode-redhat-telemetry: Skipping 'identify' event! Already sent:" logs, after reloading. A hash of the identify event will be stored under %Code location%/User/globalStorage/vscode-redhat-telemetry/cache