### PR TITLE
Fix webpack bundling, by fixing prettier version

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
     "eslint-plugin-prettier": "^3.1.4",
     "glob": "^7.1.6",
     "mocha": "^8.0.1",
-    "prettier": "^2.0.5",
+    "prettier": "2.2.1",
     "rimraf": "^3.0.2",
     "sinon": "^9.0.3",
     "sinon-chai": "^3.5.0",

--- a/test/json-schema-cache.test.ts
+++ b/test/json-schema-cache.test.ts
@@ -43,7 +43,7 @@ describe('JSON Schema Cache Tests', () => {
     pathExistsStub.resolves(false);
     readFileStub.resolves();
 
-    const cache = new JSONSchemaCache('/some/path/', memento as unknown as vscode.Memento, {} as vscode.OutputChannel);
+    const cache = new JSONSchemaCache('/some/path/', (memento as unknown) as vscode.Memento, {} as vscode.OutputChannel);
     const result = await cache.getSchema('/some/uri');
     expect(result).is.undefined;
     expect(memento.update).calledOnceWith('json-schema-key', {});
@@ -60,7 +60,7 @@ describe('JSON Schema Cache Tests', () => {
     pathExistsStub.resolves(false);
     readFileStub.resolves();
 
-    const cache = new JSONSchemaCache('/some/path/', memento as unknown as vscode.Memento, {} as vscode.OutputChannel);
+    const cache = new JSONSchemaCache('/some/path/', (memento as unknown) as vscode.Memento, {} as vscode.OutputChannel);
     const result = await cache.getSchema('/some/uri');
     expect(result).is.undefined;
     expect(memento.update).calledOnceWith('json-schema-key', mementoData);

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -45,8 +45,8 @@ describe('Telemetry Test', () => {
       outputChannel = sandbox.stub(testOutputChannel);
       telemetry = sandbox.stub(new TelemetryStub());
       telemetryChannel = new TelemetryOutputChannel(
-        outputChannel as unknown as vscode.OutputChannel,
-        telemetry as unknown as TelemetryService
+        (outputChannel as unknown) as vscode.OutputChannel,
+        (telemetry as unknown) as TelemetryService
       );
       clock = sinon.useFakeTimers();
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2169,10 +2169,10 @@ prettier@2.0.5:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
   integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
-prettier@^2.0.5:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
-  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
+prettier@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
 private@~0.1.5:
   version "0.1.8"


### PR DESCRIPTION
### What does this PR do?
It fix prettier to `2.2.1` version, as it has smaller scripts and works with webpack bundle.
This blocker for `1.0.0` release.

