### PR TITLE
Fix added configuration setting for array indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The following settings are supported:
 * `yaml.format.bracketSpacing`: Print spaces between brackets in objects
 * `yaml.format.proseWrap`: Always: wrap prose if it exeeds the print width, Never: never wrap the prose, Preserve: wrap prose as-is
 * `yaml.format.printWidth`: Specify the line length that the printer will wrap on
+* `yaml.format.sequenceItemIndent`: Specify the indent size of the sequence item from it parent
 * `yaml.validate`: Enable/disable validation feature
 * `yaml.hover`: Enable/disable hover
 * `yaml.completion`: Enable/disable autocompletion

--- a/package.json
+++ b/package.json
@@ -140,6 +140,11 @@
           "default": 80,
           "description": "Specify the line length that the printer will wrap on"
         },
+        "yaml.format.sequenceItemIndent": {
+          "type": "integer",
+          "default": 0,
+          "description": "Specify the indent size of the sequence item from it parent"
+        },
         "yaml.validate": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
### What does this PR do?
Allows users to configure the indentation size of the sequenceItem from it parent (i.e) sequence. The default is 0

![image](https://user-images.githubusercontent.com/93245779/140013026-65c7df65-a20a-4889-9994-f7549968d5dc.png)



### What issues does this PR fix or reference?
https://github.com/redhat-developer/vscode-yaml/issues/172

### Is it tested?
Yes
