### PR TITLE
Start extension on 'dockercompose' language mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "virtualWorkspaces": true
   },
   "activationEvents": [
-    "onLanguage:yaml"
+    "onLanguage:yaml",
+    "onLanguage:dockercompose"
   ],
   "keywords": [
     "kubernetes",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -107,7 +107,7 @@ export function startClient(
   // Options to control the language client
   const clientOptions: LanguageClientOptions = {
     // Register the server for on disk and newly created YAML documents
-    documentSelector: [{ language: 'yaml' }],
+    documentSelector: [{ language: 'yaml' }, { language: 'dockercompose' }, { pattern: '*.y(a)ml' }],
     synchronize: {
       // Notify the server about file changes to YAML and JSON files contained in the workspace
       fileEvents: [workspace.createFileSystemWatcher('**/*.?(e)y?(a)ml'), workspace.createFileSystemWatcher('**/*.json')],


### PR DESCRIPTION
### What does this PR do?
For some reason VSCode provide own language mode for docker compose files - https://github.com/microsoft/vscode/blob/main/extensions/yaml/package.json#L17
This PR add activation event for `dockercompose` language mode and bind yaml-ls to it.
 
### What issues does this PR fix or reference?
none

### Is it tested? How?
manually
