### PR TITLE
feat: add disableDefaultProperties

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ The following settings are supported:
 * `yaml.schemaStore.url`: URL of a schema store catalog to use when downloading schemas.
 * `yaml.customTags`: Array of custom tags that the parser will validate against. It has two ways to be used. Either an item in the array is a custom tag such as "!Ref" and it will automatically map !Ref to scalar or you can specify the type of the object !Ref should be e.g. "!Ref sequence". The type of object can be either scalar (for strings and booleans), sequence (for arrays), mapping (for objects).
 * `yaml.maxComputedItems`: The maximum number of outline symbols and folding regions computed (limited for performance reasons).
+* `yaml.disableDefaultProperties`: Disable adding not required properties with default values into completion text (default is false).
+
 - `[yaml]`: VSCode-YAML adds default configuration for all yaml files. More specifically it converts tabs to spaces to ensure valid yaml, sets the tab size, and allows live typing autocompletion and formatting, also allows code lens. These settings can be modified via the corresponding settings inside the `[yaml]` section in the settings:
   - `editor.tabSize`
   - `editor.formatOnType`

--- a/package.json
+++ b/package.json
@@ -176,6 +176,11 @@
           "default": false,
           "description": "Globally set additionalProperties to false for all objects. So if its true, no extra properties are allowed inside yaml."
         },
+        "yaml.disableDefaultProperties": {
+          "type": "boolean",
+          "default": false,
+          "description": "Disable adding not required properties with default values into completion text."
+        },
         "yaml.maxItemsComputed": {
           "type": "integer",
           "default": 5000,


### PR DESCRIPTION
### What does this PR do?
Add config to exclude not required default props from completion (**default is set to false (previous functionality)**).
The reason why users appreciated this feature is that users don't have to specify default properties. Only if the default value needs to be changed, it makes sense to add them (but not all of them automatically).

### What issues does this PR fix or reference?
https://github.com/redhat-developer/yaml-language-server/pull/606

### Is it tested? How?
In ref PR