### PR TITLE
Add 'telemetry' tag to redhat.telemetry.enabled preference

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
           "type": "boolean",
           "default": null,
           "markdownDescription": "Enable usage data and errors to be sent to Red Hat servers. Read our [privacy statement](https://developers.redhat.com/article/tool-data-collection).",
-          "scope": "window"
+          "scope": "window",
+          "tags": [ "telemetry"]
         },
         "yaml.yamlVersion": {
           "type": "string",


### PR DESCRIPTION
### What does this PR do?

Add 'telemetry' tag to redhat.telemetry.enabled preference, so the Red Hat telemetry setting can show up in VS Code's Telemetry settings, like in:

![Screenshot 2022-01-31 at 09 55 02](https://user-images.githubusercontent.com/148698/152187333-ca97d13e-be33-4405-933e-eb0b6fe24187.png)

