### PR TITLE
Support JSON Schema versions from schemastore

### DIFF
--- a/src/schema-status-bar-item.ts
+++ b/src/schema-status-bar-item.ts
@@ -39,10 +39,10 @@ interface SchemaVersionItem extends QuickPickItem {
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-const getJSONSchemas: RequestType<FileUri, MatchingJSONSchema[], {}> = new RequestType('yaml/get/all/jsonSchemas');
+const getJSONSchemasRequestType: RequestType<FileUri, MatchingJSONSchema[], {}> = new RequestType('yaml/get/all/jsonSchemas');
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-const getSchema: RequestType<FileUri, JSONSchema[], {}> = new RequestType('yaml/get/jsonSchema');
+const getSchemaRequestType: RequestType<FileUri, JSONSchema[], {}> = new RequestType('yaml/get/jsonSchema');
 
 export let statusBarItem: StatusBarItem;
 
@@ -74,7 +74,7 @@ async function updateStatusBar(editor: TextEditor): Promise<void> {
   if (editor && editor.document.languageId === 'yaml') {
     versionSelection = undefined;
     // get schema info there
-    const schema = await client.sendRequest(getSchema, editor.document.uri.toString());
+    const schema = await client.sendRequest(getSchemaRequestType, editor.document.uri.toString());
     if (!schema || schema.length === 0) {
       statusBarItem.text = 'No JSON Schema';
       statusBarItem.tooltip = 'Select JSON Schema';
@@ -85,7 +85,7 @@ async function updateStatusBar(editor: TextEditor): Promise<void> {
       if (schema[0].versions) {
         version = findUsedVersion(schema[0].versions, schema[0].uri);
       } else {
-        const schemas = await client.sendRequest(getJSONSchemas, window.activeTextEditor.document.uri.toString());
+        const schemas = await client.sendRequest(getJSONSchemasRequestType, window.activeTextEditor.document.uri.toString());
         let versionSchema: JSONSchema;
         const schemaStoreItem = findSchemaStoreItem(schemas, schema[0].uri);
         if (schemaStoreItem) {
@@ -95,7 +95,7 @@ async function updateStatusBar(editor: TextEditor): Promise<void> {
           versionSelection = createSelectVersionItem(version, versionSchema as MatchingJSONSchema);
         }
       }
-      if (version) {
+      if (version && !statusBarItem.text.includes(version)) {
         statusBarItem.text += `(${version})`;
       }
       statusBarItem.tooltip = 'Select JSON Schema';
@@ -113,7 +113,7 @@ async function updateStatusBar(editor: TextEditor): Promise<void> {
 }
 
 async function showSchemaSelection(): Promise<void> {
-  const schemas = await client.sendRequest(getJSONSchemas, window.activeTextEditor.document.uri.toString());
+  const schemas = await client.sendRequest(getJSONSchemasRequestType, window.activeTextEditor.document.uri.toString());
   const schemasPick = window.createQuickPick<SchemaItem>();
   let pickItems: SchemaItem[] = [];
 

--- a/test/json-schema-selection.test.ts
+++ b/test/json-schema-selection.test.ts
@@ -11,6 +11,7 @@ import { CommonLanguageClient } from 'vscode-languageclient';
 import * as vscode from 'vscode';
 import { TestLanguageClient } from './helper';
 import * as jsonStatusBar from '../src/schema-status-bar-item';
+
 const expect = chai.expect;
 chai.use(sinonChai);
 
@@ -103,6 +104,54 @@ describe('Status bar should work in multiple different scenarios', () => {
     expect(statusBar.text).to.equal('Multiple JSON Schemas...');
     expect(statusBar.tooltip).to.equal('Multiple JSON Schema used to validate this file, click to select one');
     expect(statusBar.backgroundColor).to.eql({ id: 'statusBarItem.warningBackground' });
+    expect(statusBar.show).calledTwice;
+  });
+
+  it('Should show JSON Schema Store schema version', async () => {
+    const context: vscode.ExtensionContext = {
+      subscriptions: [],
+    } as vscode.ExtensionContext;
+    const statusBar = ({ show: sandbox.stub() } as unknown) as vscode.StatusBarItem;
+    createStatusBarItemStub.returns(statusBar);
+    onDidChangeActiveTextEditorStub.returns({ document: { uri: vscode.Uri.parse('/foo.yaml') } });
+    clcStub.sendRequest
+      .withArgs(sinon.match.has('method', 'yaml/get/jsonSchema'), sinon.match('/foo.yaml'))
+      .resolves([{ uri: 'https://foo.com/bar.json', name: 'bar schema' }]);
+    clcStub.sendRequest
+      .withArgs(sinon.match.has('method', 'yaml/get/all/jsonSchemas'), sinon.match.any)
+      .resolves([{ versions: { '1.0.0': 'https://foo.com/bar.json' } }]);
+
+    createJSONSchemaStatusBarItem(context, (clcStub as unknown) as CommonLanguageClient);
+    const callBackFn = onDidChangeActiveTextEditorStub.firstCall.firstArg;
+    await callBackFn({ document: { languageId: 'yaml', uri: vscode.Uri.parse('/foo.yaml') } });
+
+    expect(statusBar.text).to.equal('bar schema(1.0.0)');
+    expect(statusBar.tooltip).to.equal('Select JSON Schema');
+    expect(statusBar.backgroundColor).to.be.undefined;
+    expect(statusBar.show).calledTwice;
+  });
+
+  it('Should show JSON Schema Store schema version, dont include version', async () => {
+    const context: vscode.ExtensionContext = {
+      subscriptions: [],
+    } as vscode.ExtensionContext;
+    const statusBar = ({ show: sandbox.stub() } as unknown) as vscode.StatusBarItem;
+    createStatusBarItemStub.returns(statusBar);
+    onDidChangeActiveTextEditorStub.returns({ document: { uri: vscode.Uri.parse('/foo.yaml') } });
+    clcStub.sendRequest
+      .withArgs(sinon.match.has('method', 'yaml/get/jsonSchema'), sinon.match('/foo.yaml'))
+      .resolves([{ uri: 'https://foo.com/bar.json', name: 'bar schema(1.0.0)' }]);
+    clcStub.sendRequest
+      .withArgs(sinon.match.has('method', 'yaml/get/all/jsonSchemas'), sinon.match.any)
+      .resolves([{ versions: { '1.0.0': 'https://foo.com/bar.json' } }]);
+
+    createJSONSchemaStatusBarItem(context, (clcStub as unknown) as CommonLanguageClient);
+    const callBackFn = onDidChangeActiveTextEditorStub.firstCall.firstArg;
+    await callBackFn({ document: { languageId: 'yaml', uri: vscode.Uri.parse('/foo.yaml') } });
+
+    expect(statusBar.text).to.equal('bar schema(1.0.0)');
+    expect(statusBar.tooltip).to.equal('Select JSON Schema');
+    expect(statusBar.backgroundColor).to.be.undefined;
     expect(statusBar.show).calledTwice;
   });
 });


### PR DESCRIPTION
### What does this PR do?
Adds support for versions in JSON Schema store.

Depends on https://github.com/redhat-developer/yaml-language-server/pull/675

### What issues does this PR fix or reference?
Resolve https://github.com/redhat-developer/yaml-language-server/issues/639

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
