### PR TITLE
Alternate way to add local schema in windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ On Windows with full path:
 ```json
 yaml.schemas: {
     "C:\\Users\\user\\Documents\\custom_schema.json": "someFilePattern.yaml",
+    "file:///C:/Users/user/Documents/custom_schema.json": "someFilePattern.yaml",
 }
 ```
 


### PR DESCRIPTION
### What does this PR do?
Adds new way to include local schema for **Windows System**

### What issues does this PR fix or reference?
In windows, the existing way to use local schema is non-clickable, meaning VS Code does not recognized the local path to file and opens target file, which is simple way to validate if everything is correct.

### Is it tested? How?
On Windows System,
Please point to your local schema in the format `file:///C:/path/to/local/schema.json` . Example:
```
"yaml.schemas": {
        
        "file:///C:/schema.json": "*.yaml",
```