### PR TITLE
Improvements to the contributing instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,9 +60,9 @@ All contributions are welcome!
 
 6. In `yaml-language-server/.vscode/launch.json` set `outFiles` in the `Attach to server` configuration to:
 
-  ```js
-  "outFiles": ["${workspaceFolder}/../vscode-yaml/dist/**/*.js"],
-  ```
+   ```js
+   "outFiles": ["${workspaceFolder}/../vscode-yaml/dist/**/*.js"],
+   ```
 
 7. To run the language server in VSCode, click `View -> Debug`, then from the drop down menu beside the green arrow select `Launch Extension (vscode-yaml)`, click the arrow, and a new VSCode window should load with the YAML LS running.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,27 +46,35 @@ All contributions are welcome!
             ├──── yaml-language-server/
   ```
 
-3. Run `yarn install` in both directories to initialize `node_modules` dependencies.
+3. Open the `vscode-yaml` folder in VSCode, and then add the `yaml-language-server` project to the workspace using `File -> Add Folder to Workspace...`.
 
-4. In `vscode-yaml/webpack.config.js` set the `config.entry.languageserver` property to:
+4. Run `yarn install` in both directories to initialize `node_modules` dependencies.
+
+5. In `vscode-yaml/webpack.config.js` set the `config.entry.languageserver` property to:
 
    ```js
-   languageserver: './../yaml-language-server/out/server/src/server.js',
+   languageserver: './../yaml-language-server/src/server.ts',
    ```
 
    _This will redirect which YAML LS to use._
 
-5. First run `yarn run compile` in `yaml-language-server` then in `vscode-yaml` directory
+6. In `yaml-language-server/.vscode/launch.json` set `outFiles` in the `Attach to server` configuration to:
 
-6. To run the language server in VSCode, click `View -> Debug`, then from the drop down menu beside the green arrow select `Launch Extension (vscode-yaml)`, click the arrow, and a new VSCode window should load with the YAML LS running.
+  ```js
+  "outFiles": ["${workspaceFolder}/../vscode-yaml/dist/**/*.js"],
+  ```
 
-7. To debug the language server in VSCode, from the same drop down menu
+7. To run the language server in VSCode, click `View -> Debug`, then from the drop down menu beside the green arrow select `Launch Extension (vscode-yaml)`, click the arrow, and a new VSCode window should load with the YAML LS running.
+
+8. To debug the language server in VSCode, from the same drop down menu
    select
    `Attach (yaml-language-server)`, and click the green arrow to start.
    Ensure you've opened a YAML file or else the server would have not yet
    started.
 
-**Note:** Disable or remove any existing implementations of the YAML Language server from VSCode or there will be conflicts.
+**Notes:**
+* Disable or remove any existing implementations of the YAML Language server from VSCode or there will be conflicts.
+* If you still have issues you can also try changing the debug port for the language server. To do this change the port in the `Attach to server` configuration to another value in `yaml-language-server/.vscode/launch.json`, then change update the port in `debugOptions` (`'--inspect=6009'`) to the new port in the file `vscode-yaml/src/node/yamlClientMain.ts`.
 
 ##### Developing the server side
 


### PR DESCRIPTION
### What does this PR do?
Some improvements to contributing guidelines to make it easier to start debugging out of the box - closes #745.

### What issues does this PR fix or reference?
* Update the language server to the ts file to avoid having to compile the language server project for each change
* Removed the unnecessary compile step (its done anyway in the pre-launch when debugging the extension)
* Added a line to update the outFiles of the server launch config to the correct path
* Added a note to fix an issue I ran into when debugging where I had a port clash with another plugin
