### PR TITLE
Use sftp to upload vsix file

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ node('rhel8'){
 
   stage 'Upload vscode-yaml to staging'
   def vsix = findFiles(glob: '**.vsix')
-  sh "rsync -Pzrlt --rsh=ssh --protocol=28 ${vsix[0].path} ${UPLOAD_LOCATION}/snapshots/vscode-yaml/"
+  sh "sftp -C ${UPLOAD_LOCATION}/snapshots/vscode-yaml/ <<< \$'put -p \"${vsix[0].path}\"'"
   stash name:'vsix', includes:vsix[0].path
 }
 


### PR DESCRIPTION
### What does this PR do?
On Jenkins we have problem with uploading `vsix` file to staging server, this PR use `sftp` 

### What issues does this PR fix or reference?
none, found during `1.7.0` release

