### PR TITLE
add parent skeleton setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ The following settings are supported:
 * `yaml.customTags`: Array of custom tags that the parser will validate against. It has two ways to be used. Either an item in the array is a custom tag such as "!Ref" and it will automatically map !Ref to a scalar, or you can specify the type of the object !Ref should be, e.g. "!Ref sequence". The type of object can be either scalar (for strings and booleans), sequence (for arrays), mapping (for objects).
 * `yaml.maxComputedItems`: The maximum number of outline symbols and folding regions computed (limited for performance reasons).
 * `yaml.disableDefaultProperties`: Disable adding not required properties with default values into completion text (default is false).
+* `yaml.suggest.parentSkeletonSelectedFirst`: If true, the user must select some parent skeleton first before autocompletion starts to suggest the rest of the properties. When the YAML object is not empty, autocompletion ignores this setting and returns all properties and skeletons.
 
-- `[yaml]`: VSCode-YAML adds default configuration for all YAML files. More specifically, it converts tabs to spaces to ensure valid YAML, sets the tab size, allows live typing autocompletion and formatting, also allows code lens. These settings can be modified via the corresponding settings inside the `[yaml]` section in the settings:
+- `[yaml]`: VSCode-YAML adds default configuration for all YAML files. More specifically, it converts tabs to spaces to ensure valid YAML, sets the tab size, allows live typing autocompletion and formatting, and also allows code lens. These settings can be modified via the corresponding settings inside the `[yaml]` section in the settings:
   - `editor.tabSize`
   - `editor.formatOnType`
   - `editor.codeLens`

--- a/package.json
+++ b/package.json
@@ -188,6 +188,11 @@
           "type": "integer",
           "default": 5000,
           "description": "The maximum number of outline symbols and folding regions computed (limited for performance reasons)."
+        },
+        "yaml.suggest.parentSkeletonSelectedFirst": {
+          "type":"boolean",
+          "default": false,
+          "description": "If true, the user must select some parent skeleton first before autocompletion starts to suggest the rest of the properties. When yaml object is not empty, autocompletion ignores this setting and returns all properties and skeletons"
         }
       }
     },


### PR DESCRIPTION
Adds the setting for parent Skeleton order that is available from the YAML LS when doing code assists.

### What issues does this PR fix or reference?

https://github.com/redhat-developer/yaml-language-server/pull/691

### Is it tested? How?
Tested on YAML LSP, catching up with the settings.