### PR TITLE
Add title to extension configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
       }
     ],
     "configuration": {
+      "title:": "YAML",
       "properties": {
         "redhat.telemetry.enabled": {
           "type": "boolean",


### PR DESCRIPTION
### What does this PR do?
According to the [VSCode configuration schema](https://code.visualstudio.com/api/references/contribution-points#Configuration-schema), the `.contributes.configuration.title` property seems to be required and is currently missing 
in vscode-yaml. This PR adds the title to configuration.

### What issues does this PR fix or reference?
None

### Is it tested? How?

- `npm install`
- `npm run build`
- `vsce package`

Then add `.vsix` to VSCode, made sure extension still works on YAML and I verified configuration still has the YAML settings there (and only once). Also clicked the 'extension settings' from the extensions list and I also got to all the YAML settings.