### PR TITLE
Fix signature of ExtensionAPI.requestSchemaContent

### DIFF
--- a/src/schema-extension-api.ts
+++ b/src/schema-extension-api.ts
@@ -39,7 +39,7 @@ export interface ExtensionAPI {
   registerContributor(
     schema: string,
     requestSchema: (resource: string) => string,
-    requestSchemaContent: (uri: string) => string,
+    requestSchemaContent: (uri: string) => Promise<string> | string,
     label?: string
   ): boolean;
   modifySchemaContent(schemaModifications: SchemaAdditions | SchemaDeletions): Promise<void>;
@@ -65,7 +65,7 @@ class SchemaExtensionAPI implements ExtensionAPI {
   public registerContributor(
     schema: string,
     requestSchema: (resource: string) => string,
-    requestSchemaContent: (uri: string) => string,
+    requestSchemaContent: (uri: string) => Promise<string> | string,
     label?: string
   ): boolean {
     if (this._customSchemaContributors[schema]) {


### PR DESCRIPTION
### What does this PR do?
Changes the signature of `ExtensionAPI.requestSchemaContent` to include `Promise<string>` as a return value since the internal interface and the implementation supports it.

It's not that relevant, but makes it more obvious to users that this is an option.
