### PR TITLE
Add map key order config

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The following settings are supported:
 - `http.proxyStrictSSL`: If true the proxy server certificate should be verified against the list of supplied CAs. Default is false.
 - `yaml.style.flowMapping` : Forbids flow style mappings if set to `forbid`
 - `yaml.style.flowSequence` : Forbids flow style sequences if set to `forbid`
-In to your settings.
+- `yaml.keyOrdering` : Enforces alphabetical ordering of keys in mappings when set to `true`. Default is `false`
 
 ## Adding custom tags
 

--- a/package.json
+++ b/package.json
@@ -213,6 +213,11 @@
           ],
           "default": "allow",
           "description": "Forbid flow style sequences"
+        },
+        "yaml.keyOrdering": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enforces alphabetical ordering of keys in mappings when set to true"
         }
       }
     },


### PR DESCRIPTION
### What does this PR do?
Adds the config property for enforcing alphabetical key ordering of maps

### What issues does this PR fix or reference?
n/a

### Is it tested? How?
existing tests
