### PR TITLE
Make it easier to build latest/custom yaml-language-server.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,6 +13,7 @@
       "outFiles": ["${workspaceRoot}/dist/**/*.js"],
       "preLaunchTask": "compile typescript",
       "env": {
+        "DEBUG_VSCODE_YAML":"true",
         "VSCODE_REDHAT_TELEMETRY_DEBUG":"true"
       }
     },
@@ -28,7 +29,10 @@
         "--extensionTestsPath=${workspaceFolder}/out/test",
         "${workspaceRoot}/test/testFixture"
       ],
-      "outFiles": ["${workspaceFolder}/out/test/**/*.js"]
+      "outFiles": ["${workspaceFolder}/out/test/**/*.js"],
+      "env": {
+        "DEBUG_VSCODE_YAML":"true"
+      }
     },
     {
       "name": "Launch Web Extension",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,23 +50,9 @@ All contributions are welcome!
 
 4. Run `yarn install` in both directories to initialize `node_modules` dependencies.
 
-5. In `vscode-yaml/webpack.config.js` set the `config.entry.languageserver` property to:
+5. To run the language server in VSCode, click `View -> Debug`, then from the drop down menu beside the green arrow select `Launch Extension (vscode-yaml)`, click the arrow, and a new VSCode window should load with the YAML LS running.
 
-   ```js
-   languageserver: './../yaml-language-server/src/server.ts',
-   ```
-
-   _This will redirect which YAML LS to use._
-
-6. In `yaml-language-server/.vscode/launch.json` set `outFiles` in the `Attach to server` configuration to:
-
-   ```js
-   "outFiles": ["${workspaceFolder}/../vscode-yaml/dist/**/*.js"],
-   ```
-
-7. To run the language server in VSCode, click `View -> Debug`, then from the drop down menu beside the green arrow select `Launch Extension (vscode-yaml)`, click the arrow, and a new VSCode window should load with the YAML LS running.
-
-8. To debug the language server in VSCode, from the same drop down menu
+6. To debug the language server in VSCode, from the same drop down menu
    select
    `Attach (yaml-language-server)`, and click the green arrow to start.
    Ensure you've opened a YAML file or else the server would have not yet

--- a/src/node/yamlClientMain.ts
+++ b/src/node/yamlClientMain.ts
@@ -17,8 +17,13 @@ export async function activate(context: ExtensionContext): Promise<SchemaExtensi
   // Create Telemetry Service
   const telemetry = await (await getRedHatService(context)).getTelemetryService();
 
-  // The YAML language server is implemented in node
-  const serverModule = context.asAbsolutePath('./dist/languageserver.js');
+  let serverModule: string;
+  if (startedFromSources()) {
+    serverModule = context.asAbsolutePath('../yaml-language-server/out/server/src/server.js');
+  } else {
+    // The YAML language server is implemented in node
+    serverModule = context.asAbsolutePath('./dist/languageserver.js');
+  }
 
   // The debug options for the server
   const debugOptions = { execArgv: ['--nolazy', '--inspect=6009'] };
@@ -40,4 +45,8 @@ export async function activate(context: ExtensionContext): Promise<SchemaExtensi
   };
 
   return startClient(context, newLanguageClient, runtime);
+}
+
+function startedFromSources(): boolean {
+  return process.env['DEBUG_VSCODE_YAML'] === 'true';
 }


### PR DESCRIPTION
Since vscode-yaml depends on yaml-language-server directly, the latest version will always be under node_modules. For contributors, it's convenient to test against an instance built from sources. Assume local instance is in a sibling directory called 'yaml-language-server'.

@msivasubramaniaan , let me know if this makes sense. It should be easier to run a local instance this way.