### PR TITLE
renamed yaml.extension.recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The following settings are supported:
 - `yaml.style.flowMapping` : Forbids flow style mappings if set to `forbid`
 - `yaml.style.flowSequence` : Forbids flow style sequences if set to `forbid`
 - `yaml.keyOrdering` : Enforces alphabetical ordering of keys in mappings when set to `true`. Default is `false`
+- `yaml.extension.recommendations` : Enable extension recommendations for YAML files. Default is `true`
 
 ## Adding custom tags
 

--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
           "default": false,
           "description": "Enforces alphabetical ordering of keys in mappings when set to true"
         },
-        "yaml.recommendations.show": {
+        "yaml.extension.recommendations": {
           "type": "boolean",
           "default": "true",
           "description": "Suggest additional extensions based on YAML usage."

--- a/src/recommendation/openShiftToolkit.ts
+++ b/src/recommendation/openShiftToolkit.ts
@@ -13,7 +13,7 @@ import { IHandler } from './handler';
 const EXTENSION_NAME = 'redhat.vscode-openshift-connector';
 const GH_ORG_URL = `https://github.com/redhat-developer/vscode-openshift-tools`;
 const RECOMMENDATION_MESSAGE = `The workspace has a devfile.yaml. Install [OpenShift Toolkit](${GH_ORG_URL}) extension for assistance with deploying to a cluster?`;
-const YAML_RECOMMENDATIONS_SHOW = 'yaml.recommendations.show';
+const YAML_EXTENSION_RECOMMENDATIONS = 'yaml.extension.recommendations';
 
 function isDevfileYAML(uri: vscode.Uri): boolean {
   if (fs.lstatSync(uri.fsPath).isDirectory()) {
@@ -24,7 +24,7 @@ function isDevfileYAML(uri: vscode.Uri): boolean {
 }
 
 export function initializeRecommendation(context: vscode.ExtensionContext, handler: IHandler): void {
-  const show = vscode.workspace.getConfiguration().get(YAML_RECOMMENDATIONS_SHOW);
+  const show = vscode.workspace.getConfiguration().get(YAML_EXTENSION_RECOMMENDATIONS);
   if (!show) {
     return;
   }


### PR DESCRIPTION
### What does this PR do?
Renamed `yaml.extension.recommendations` instead of yaml.recommendations.show

### What issues does this PR fix or reference?
no Red

### Is it tested? How?
NA
