### PR TITLE
Support Multiple Custom Kubernetes Versions and CRDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,6 +166,11 @@
           "default": [],
           "description": "Custom tags for the parser to use"
         },
+        "yaml.kubernetesSchemaURLs": {
+          "type": "array",
+          "default": [],
+          "description": "URLs to Kubernetes schemas"
+        },
         "yaml.schemaStore.enable": {
           "type": "boolean",
           "default": true,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -75,6 +75,12 @@ namespace DynamicCustomSchemaRequestRegistration {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace KubernetesSchemaURLsNotification {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  export const type: NotificationType<string[]> = new NotificationType('yaml/kubernetesSchemaURLs');
+}
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
 namespace ResultLimitReachedNotification {
   // eslint-disable-next-line @typescript-eslint/ban-types
   export const type: NotificationType<string> = new NotificationType('yaml/resultLimitReached');
@@ -161,6 +167,7 @@ export function startClient(
         client.sendNotification(SchemaAssociationNotification.type, getSchemaAssociations());
         findConflicts();
       });
+      client.sendNotification(KubernetesSchemaURLsNotification.type, getKubernetesSchemaURLs());
       // Tell the server that the client is ready to provide custom schema content
       client.sendNotification(DynamicCustomSchemaRequestRegistration.type);
       // Tell the server that the client supports schema requests sent directly to it
@@ -227,6 +234,10 @@ function findConflicts(): void {
   if (conflictingExtensions.length > 0) {
     showUninstallConflictsNotification(conflictingExtensions);
   }
+}
+
+function getKubernetesSchemaURLs(): string[] {
+  return workspace.getConfiguration('yaml').get('kubernetesSchemaURLs') || [];
 }
 
 function getSchemaAssociations(): ISchemaAssociation[] {


### PR DESCRIPTION
### What does this PR do?

Adds the `yaml.kubernetesSchemaUrls` setting and its corresponding notification to support multiple custom kubernetes versions and Custom Resource Definitions (CRDs).

### What issues does this PR fix or reference?

https://github.com/redhat-developer/yaml-language-server/pull/841

### Is it tested? How?
- Manually building this vscode extension and the linked yaml language server and then using/testing it.
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
