### PR TITLE
Add languages `yaml-textmate` & `yaml-tmlanguage`

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -116,7 +116,7 @@ export function startClient(
   // Options to control the language client
   const clientOptions: LanguageClientOptions = {
     // Register the server for on disk and newly created YAML documents
-    documentSelector: [{ language: 'yaml' }, { language: 'dockercompose' }, { pattern: '*.y(a)ml' }],
+    documentSelector: [{ language: 'yaml' }, { language: 'dockercompose' }, { language: 'yaml-textmate' }, { language: 'yaml-tmlanguage' }, { pattern: '*.y(a)ml' }],
     synchronize: {
       // Notify the server about file changes to YAML and JSON files contained in the workspace
       fileEvents: [workspace.createFileSystemWatcher('**/*.?(e)y?(a)ml'), workspace.createFileSystemWatcher('**/*.json')],


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-yaml/issues/1092

I could add them to `"activationEvents"` as well
but the 3rd party extensions can activate this one instead via `"extensionDependencies"`
https://github.com/redhat-developer/vscode-yaml/blob/e696d9b25153a8ce84b22738f01cbc931a3f87a2/package.json#L41-L44

---

also I think `*.y(a)ml` is a invalid [glob pattern](https://code.visualstudio.com/docs/editor/glob-patterns)
https://github.com/redhat-developer/vscode-yaml/blob/e696d9b25153a8ce84b22738f01cbc931a3f87a2/src/extension.ts#L119