### PR TITLE
Stabilize UI tests

### DIFF
--- a/test/ui-test/customTagsTest.ts
+++ b/test/ui-test/customTagsTest.ts
@@ -43,6 +43,7 @@ export function customTagsTest(): void {
         await textSettingsEditor.typeTextAt(coor[0], coor[1], '    "customTag1"');
       }
       await textSettingsEditor.save();
+      await hardDelay(1_000);
 
       editor = (await editorView.openEditor(yamlFileName)) as TextEditor;
       await editor.setText('custom');


### PR DESCRIPTION
### What does this PR do?
This PR uses delays in order to get the "YAML custom tags works as expected" test passing consistently.

My best guess as to why this works is that it takes bit of time for the setting change to propagate to the language server.

### What issues does this PR fix or reference?
Fixes #1119

### Is it tested? How?
Run the UI tests locally. Before this PR, they should fail consistently, and after this PR, they should pass consistently.
