### PR TITLE
Add formatting option for trailing comma

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,11 @@
           "default": 80,
           "description": "Specify the line length that the printer will wrap on"
         },
+        "yaml.format.trailingComma": {
+          "type": "boolean",
+          "default": true,
+          "description": "Specify if trailing commas should be used in JSON-like segments of the YAML"
+        },
         "yaml.validate": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
### What does this PR do?
Adds an option `yaml.format.trailingComma` to set if trailing commas should be used JSON-style blocks like this:

```yaml
{
  key: 'value',
  food: 'raisins',
  airport: 'YYZ',
  lightened_bulb: 'illuminating',
}
```

See redhat-developer/yaml-language-server#1063, this PR requires that PR in order to work.

### What issues does this PR fix or reference?
Fixes #1112

### Is it tested? How?
Unit tests in yaml-language-server. I can look into integration tests here if you think it's helpful.
