### PR TITLE
update settings.json for setting default formatter as yaml on docker compose and github actions

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import { workspace, ExtensionContext, extensions, window, commands, Uri } from 'vscode';
+import { workspace, ExtensionContext, extensions, window, commands, Uri, ConfigurationTarget } from 'vscode';
 import {
   CommonLanguageClient,
   LanguageClientOptions,
@@ -157,7 +157,7 @@ export function startClient(
   findConflicts();
   client
     .onReady()
-    .then(() => {
+    .then(async () => {
       // Send a notification to the server with any YAML schema associations in all extensions
       client.sendNotification(SchemaAssociationNotification.type, getSchemaAssociations());
 
@@ -214,12 +214,31 @@ export function startClient(
       });
 
       initializeRecommendation(context);
+
+      await setDefaultFormatter(['dockercompose', 'github-actions-workflow']);
     })
     .catch((err) => {
       sendStartupTelemetryEvent(runtime.telemetry, false, err);
     });
 
   return schemaExtensionAPI;
+}
+
+/**
+ * set redhat.vscode-yaml as default formatter
+ * @param extensions [dockercompose, github-actions-workflow]
+ */
+async function setDefaultFormatter(extensions: string[]): Promise<void> {
+  const config = workspace.getConfiguration();
+  extensions.forEach(async (extension) => {
+    const extensionConf = config.get<Record<string, string>>(`[${extension}]`) || {};
+    if (extensionConf) {
+      if (extensionConf['editor.defaultFormatter'] === undefined) {
+        extensionConf['editor.defaultFormatter'] = 'redhat.vscode-yaml';
+        await config.update(`[${extension}]`, extensionConf, ConfigurationTarget.Global);
+      }
+    }
+  });
 }
 
 /**


### PR DESCRIPTION
### What does this PR do?
This PR will make vscode-yaml as default formatter for docker compose and github actions. Will do one more PR on client side as well

### What issues does this PR fix or reference?
https://github.com/redhat-developer/yaml-language-server/issues/1071

### Is it tested? How?
Yes with existing test case
