### PR TITLE
l10n missing from .vsix

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -35,6 +35,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Install latest yaml-language-server
+      - name: Update yaml-language-server
+        run: npm i yaml-language-server@next
+
       # Build extension
       - name: Run build
         run: npm run build

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -20,6 +20,7 @@ CONTRIBUTING.md
 .vscode-test-web/**
 **/**.vsix
 **/**.tar.gz
+test-resources
 !node_modules/prettier/index.js
 !node_modules/prettier/third-party.js
 !node_modules/prettier/parser-yaml.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1189,6 +1189,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@vscode/l10n": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
+      "license": "MIT"
+    },
     "node_modules/@vscode/test-electron": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
@@ -10735,11 +10741,12 @@
       }
     },
     "node_modules/yaml-language-server": {
-      "version": "1.19.1-cd20ba6.0",
-      "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.19.1-cd20ba6.0.tgz",
-      "integrity": "sha512-Km4iwgEjEInqGPg2Y6GT3s501Pt+i9Jzo2kJCR+UghsdjwFEl3GVEQCj75swo21nkW1J27EwjX46BIH/+XYf+A==",
+      "version": "1.19.1-91e4029.0",
+      "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.19.1-91e4029.0.tgz",
+      "integrity": "sha512-JdRylLEWeWdxWeSMN7Jbg5wZHC57D6BOFv/eQW34tGOounrxx/XME74EJQgaER+I65H89sYbiv4wSDTUvH3anA==",
       "license": "MIT",
       "dependencies": {
+        "@vscode/l10n": "^0.0.18",
         "ajv": "^8.17.1",
         "ajv-draft-04": "^1.0.0",
         "lodash": "4.17.21",
@@ -10749,7 +10756,6 @@
         "vscode-languageserver": "^9.0.0",
         "vscode-languageserver-textdocument": "^1.0.1",
         "vscode-languageserver-types": "^3.16.0",
-        "vscode-nls": "^5.0.0",
         "vscode-uri": "^3.0.2",
         "yaml": "2.7.1"
       },
@@ -10807,12 +10813,6 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
-    },
-    "node_modules/yaml-language-server/node_modules/vscode-nls": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
-      "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==",
-      "license": "MIT"
     },
     "node_modules/yaml-language-server/node_modules/vscode-uri": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -256,9 +256,10 @@
     "lint": "eslint -c .eslintrc.js --ext .ts src test",
     "test": "npm run test-compile && sh scripts/e2e.sh",
     "ui-test": "npm run test-compile && extest setup-and-run out/test/ui-test/allTestsSuite.js -c 1.76.2",
-    "vscode:prepublish": "webpack --mode production",
+    "vscode:prepublish": "webpack --mode production && npm run copy-l10n",
+    "copy-l10n": "cp -r node_modules/yaml-language-server/l10n dist/l10n",
     "watch": "webpack --mode development --watch --info-verbosity verbose",
-    "test-compile": "npm run clean && tsc -p ./ && webpack --mode development",
+    "test-compile": "npm run clean && tsc -p ./ && webpack --mode development && npm run copy-l10n",
     "run-in-chromium": "npm run compile && vscode-test-web --browserType=chromium --extensionDevelopmentPath=. ."
   },
   "devDependencies": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,7 +113,7 @@ export function startClient(
 ): SchemaExtensionAPI {
   const telemetryErrorHandler = new TelemetryErrorHandler(runtime.telemetry, lsName, 4);
   const outputChannel = window.createOutputChannel(lsName);
-  const l10nPath = context.asAbsolutePath('../yaml-language-server/l10n');
+  const l10nPath = context.asAbsolutePath('./dist/l10n');
   // Options to control the language client
   const clientOptions: LanguageClientOptions = {
     // Register the server for on disk and newly created YAML documents


### PR DESCRIPTION
### What does this PR do?
1. The `l10n` folder, which contains all the translations, was not present anywhere in the built .vsix. The translations are required in order to run yaml-language-server, so I copied from yaml-language-server to `dist/l10n`.
2. The location of l10n was listed as `../yaml-language-server/l10n`. This doesn't work if yaml-language-server isn't cloned locally, and doesn't work when running as a .vsix, so I changed it to `./dist/l10n`.
3. During the CI run, npm isn't installing the latest prerelease of yaml-language-server. I added a step to force it to use the latest yaml-language-server. This is important, because the above bugs could have been caught earlier if we were actually testing against the newest yaml-language-server.

### What issues does this PR fix or reference?
Fixes #1152

### Is it tested? How?
Yes, with the existing test suites.
