### PR TITLE
Fix prerelease GitHub Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
           node-version: 20
       - name: Set version to prerelease version
         run: |
-          node change-version-to-prerelease.mjs
+          node ./scripts/change-version-to-prerelease.mjs
           echo "publishPreReleaseFlag=--pre-release" >> $GITHUB_ENV
         if: ${{ github.event_name == 'schedule' || inputs.publishPreRelease == 'true'}}
       - name: Install dependencies
@@ -130,6 +130,10 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: 20
+    - name: Set version to prerelease version
+      run: |
+        node ./scripts/change-version-to-prerelease.mjs
+      if: ${{ github.event_name == 'schedule' || inputs.publishPreRelease == 'true'}}
     - name: Install dependencies
       run: |
         npm install -g typescript "@vscode/vsce" "ovsx"


### PR DESCRIPTION
### What does this PR do?
Fix the GitHub Action that handles prereleases. I had the wrong path for the script to bump the version. I also had to rerun the bump script in the "publish" step so that the version being used to reference the `.vsix` was correct.

### What issues does this PR fix or reference?
See the latest "release" run in the GitHub Actions tab

### Is it tested? How?
- [x] I'll run it on my fork this time to make sure it works (except for the final publishing step which should fail without the credentials: https://github.com/datho7561/vscode-yaml/actions/runs/18163608808/job/51700528231
