### PR TITLE
Don't tag prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
         uses: "marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "${{ env.EXT_VERSION }}"
+          automatic_release_tag: "${{ github.event_name != 'schedule' && inputs.publishPreRelease != 'true' && env.EXT_VERSION || null }}"
           draft: true
           files: |
             vscode-yaml-${{ env.EXT_VERSION }}-${{github.run_number}}*.vsix


### PR DESCRIPTION
### What does this PR do?
Change the options passed to marvinpinto/action-automatic-releases so that prereleases don't get automatically tagged.

### What issues does this PR fix or reference?
Fixes #1162

### Is it tested? How?
Nope, I don't think there's a good way to test it without actually running the action.