### PR TITLE
Another fix for prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,9 +109,10 @@ jobs:
           if-no-files-found: error
       - name: Publish to GH Release Tab
         uses: "marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0"
+        if: ${{ github.event_name != 'schedule' && inputs.publishPreRelease != 'true' }}
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "${{ github.event_name != 'schedule' && inputs.publishPreRelease != 'true' && env.EXT_VERSION || null }}"
+          automatic_release_tag: "${{ env.EXT_VERSION }}"
           draft: true
           files: |
             vscode-yaml-${{ env.EXT_VERSION }}-${{github.run_number}}*.vsix


### PR DESCRIPTION
### What does this PR do?
Hopefully fixes prerelease builds.

In order to skip tagging the prerelease version, we need to entirely skip the publish to GitHub Releases step. Passing a null tag causes the step to error, which ends the build.

### What issues does this PR fix or reference?
See https://github.com/redhat-developer/vscode-yaml/actions/runs/18216654005/job/51867270159

### Is it tested? How?
We can only really test it by running it.
