### PR TITLE
Improve documentation for the `yaml.schemas` setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,11 @@
         "yaml.schemas": {
           "type": "object",
           "default": {},
-          "description": "Associate schemas to YAML files in the current workspace"
+          "additionalProperties": {
+            "type": "string",
+            "markdownDescription": "- **Key**: The path or URL of the schema to use\n- **Value**: A glob pattern specifying which files the schema should be used on"
+          },
+          "markdownDescription": "Associate schemas to YAML files in the current workspace. The expected value of this configuration option is a string to string map:\n- **Key**: The path or URL of the schema to use\n- **Value**: A glob pattern specifying which files the schema should be used on"
         },
         "yaml.format.enable": {
           "type": "boolean",


### PR DESCRIPTION
### What does this PR do?
Improves the documentation for the `yaml.schemas` setting by specifying that the expected value is a string-to-string map, where the keys represent schema locations and the values are globs for the files that the schema applies to.

### What issues does this PR fix or reference?
Fixes #1147

### Is it tested? How?
It's a documentation change, so I'll ask a couple people if it makes sense.