### PR TITLE
Settings for "auto-detect Kubernetes crd schema"

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
         },
         "yaml.kubernetesCRDStore.url": {
           "type": "string",
-          "description": "The base URL for fetching well-known Custom Resource Definition (CRD) schemas,
+          "description": "The base URL for fetching well-known Custom Resource Definition (CRD) schemas",
           "default": "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main"
         },
         "yaml.format.enable": {


### PR DESCRIPTION
### What does this PR do?
Adds settings to enable/disable the CRD schema auto-detection feature and change the repository used to find CRD schemas.

Use https://raw.githubusercontent.com/nlamirault/crd-schema-store/refs/heads/main/schemas to test an alternate store of CRD schemas.

### What issues does this PR fix or reference?
See https://github.com/redhat-developer/yaml-language-server/pull/1050

### Is it tested? How?
I manually tested that the settings worked.
