### PR TITLE
Fix resolving schema content on web

### DIFF
--- a/package.json
+++ b/package.json
@@ -287,7 +287,7 @@
     "smoke-test": "npm run test-compile && vscode-test smoke-test/*",
     "compile-smoke-test-web": "webpack --config smoke-test/webpack.config",
     "smoke-test-web": "npm run compile-smoke-test-web && vscode-test-web --extensionDevelopmentPath=. --extensionTestsPath=./out/smoke-test/smoke-test-runner.js ./smoke-test",
-    "run-in-chromium": "npm run compile && vscode-test-web --browserType=chromium --extensionDevelopmentPath=. ."
+    "run-in-chromium": "npm run compile && vscode-test-web --browserType=chromium --extensionDevelopmentPath=. smoke-test"
   },
   "devDependencies": {
     "@types/chai": "^4.2.12",

--- a/smoke-test/.vscode/settings.json
+++ b/smoke-test/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "yaml.schemas": {
+    "dressSize.json": "references-schema-settings.yaml"
+  }
+}

--- a/smoke-test/references-schema-settings.yaml
+++ b/smoke-test/references-schema-settings.yaml
@@ -1,0 +1,2 @@
+dress:
+  size: -2

--- a/smoke-test/smoke.test.ts
+++ b/smoke-test/smoke.test.ts
@@ -9,12 +9,19 @@ suite('Smoke test suite', function () {
   const DIAGNOSTICS_DELAY = 4_000;
 
   const SCHEMA_INSTANCE_NAME = 'references-schema.yaml';
+  const THROUGH_SETTINGS_NAME = 'references-schema-settings.yaml';
 
   let schemaInstanceUri: URI;
+  let throughSettingsUri: URI;
 
   this.beforeAll(async function () {
     const workspaceUri = vscode.workspace.workspaceFolders[0].uri;
-    schemaInstanceUri = workspaceUri.with({ path: workspaceUri.path + (workspaceUri.path.endsWith('/') ? '' : '/') + SCHEMA_INSTANCE_NAME });
+    schemaInstanceUri = workspaceUri.with({
+      path: workspaceUri.path + (workspaceUri.path.endsWith('/') ? '' : '/') + SCHEMA_INSTANCE_NAME,
+    });
+    throughSettingsUri = workspaceUri.with({
+      path: workspaceUri.path + (workspaceUri.path.endsWith('/') ? '' : '/') + THROUGH_SETTINGS_NAME,
+    });
   });
 
   test('instance has right diagnostics', async function () {
@@ -22,6 +29,16 @@ suite('Smoke test suite', function () {
     await vscode.window.showTextDocument(textDocument);
     await new Promise((resolve) => setTimeout(resolve, DIAGNOSTICS_DELAY));
     const diagnostics = vscode.languages.getDiagnostics(schemaInstanceUri);
+
+    assert.strictEqual(diagnostics.length, 1);
+    assert.strictEqual(diagnostics[0].message, 'Value is below the minimum of 0.');
+  });
+
+  test('has right diagnostics when schema is referenced through settings', async function () {
+    const textDocument = await vscode.workspace.openTextDocument(throughSettingsUri);
+    await vscode.window.showTextDocument(textDocument);
+    await new Promise((resolve) => setTimeout(resolve, DIAGNOSTICS_DELAY));
+    const diagnostics = vscode.languages.getDiagnostics(throughSettingsUri);
 
     assert.strictEqual(diagnostics.length, 1);
     assert.strictEqual(diagnostics[0].message, 'Value is below the minimum of 0.');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import { workspace, ExtensionContext, extensions, window, commands, Uri, l10n } from 'vscode';
+import { workspace, ExtensionContext, extensions, window, commands, Uri } from 'vscode';
 import {
   CommonLanguageClient,
   LanguageClientOptions,
@@ -66,6 +66,8 @@ namespace FSReadFile {
   // eslint-disable-next-line @typescript-eslint/ban-types
   export const type: RequestType<string, string, {}> = new RequestType('fs/readFile');
 }
+
+export const FSReadUriType: RequestType<string, string, unknown> = new RequestType('fs/readUri');
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 namespace DynamicCustomSchemaRequestRegistration {
@@ -197,6 +199,16 @@ export function startClient(
           const workspaceFolderBasedPath = workspace.workspaceFolders[0].uri.with({ path: fsPath });
           const uint8array = await workspace.fs.readFile(workspaceFolderBasedPath);
           return new TextDecoder().decode(uint8array);
+        }
+      });
+      client.onRequest(FSReadUriType, async (uri: string) => {
+        try {
+          const parsedUri = Uri.parse(uri);
+          window.showInformationMessage(`uri: ${parsedUri.toString()}`);
+          const uint8array = await workspace.fs.readFile(parsedUri);
+          return new TextDecoder().decode(uint8array);
+        } catch (e) {
+          window.showErrorMessage(`Error while retrieving content of '${uri}': ${e}`);
         }
       });
 


### PR DESCRIPTION
### What does this PR do?
Use a new extension point, which requests schema content by URI instead of filepath.
This is helpful, since web instances may use URIs with schemas other than `file://` to refer to the files in the workspace.

Add a smoke test.

Requires https://github.com/redhat-developer/yaml-language-server/pull/1173

### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/vscode-yaml/issues/1194

### Is it tested? How?
New integration/smoke test