### PR TITLE
Add yaml-lint-disable comment to suppress diagnostics per-line

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,12 @@ The following settings are supported:
 
 ## Suppressing diagnostics
 
-You can suppress specific validation warnings on a per-line basis by adding a `# yaml-lint-disable` comment on the line immediately before the one producing the diagnostic.
+You can suppress specific validation warnings on a per-line basis by adding a `# yaml-language-server-disable` comment on the line immediately before the one producing the diagnostic.
 
 ### Suppress all diagnostics on a line
 
 ```yaml
-# yaml-lint-disable
+# yaml-language-server-disable
 version: 123
 ```
 
@@ -85,12 +85,12 @@ version: 123
 Provide one or more message substrings (comma-separated, case-insensitive). Only diagnostics whose message contains a matching substring will be suppressed; the rest are kept.
 
 ```yaml
-# yaml-lint-disable Incorrect type
+# yaml-language-server-disable Incorrect type
 version: 123
 ```
 
 ```yaml
-# yaml-lint-disable Incorrect type, not accepted
+# yaml-language-server-disable Incorrect type, not accepted
 version: 123
 ```
 


### PR DESCRIPTION
### What does this PR do?

Update the README to document the added support for suppressing linter diagnostics on a per-line basis using a `yaml-lint-disable` comment placed on the line immediately before the one producing the diagnostic.

### What issues does this PR fix or reference?

- Resolves https://github.com/redhat-developer/vscode-yaml/issues/666
- https://github.com/redhat-developer/yaml-language-server/pull/1189
