### PR TITLE
Fix documentation of `yaml.schemas` setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,10 +122,20 @@
           "type": "object",
           "default": {},
           "additionalProperties": {
-            "type": "string",
-            "markdownDescription": "- **Key**: The path or URL of the schema to use\n- **Value**: A glob pattern specifying which files the schema should be used on"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ],
+            "markdownDescription": "- **Key**: The path or URL of the schema to use\n- **Value**: A glob pattern or list of glob patterns specifying which files the schema should be used on"
           },
-          "markdownDescription": "Associate schemas to YAML files in the current workspace. The expected value of this configuration option is a string to string map:\n- **Key**: The path or URL of the schema to use\n- **Value**: A glob pattern specifying which files the schema should be used on"
+          "markdownDescription": "Associate schemas to YAML files in the current workspace. The expected value of this configuration option is a string to string map:\n- **Key**: The path or URL of the schema to use\n- **Value**: A glob pattern or list of glob patterns specifying which files the schema should be used on"
         },
         "yaml.kubernetesCRDStore.enable": {
           "type": "boolean",


### PR DESCRIPTION
### What does this PR do?
I've updated the documentation and JSON Schema to reflect that you can use a single glob or an array of globs for `yaml.schemas`.

### What issues does this PR fix or reference?
Fixes #1207

### Is it tested? How?
N/A
