### PR TITLE
Make `yaml.validate` and `yaml.format.enable` language-overridable

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,8 @@
         "yaml.format.enable": {
           "type": "boolean",
           "default": true,
-          "description": "Enable/disable default YAML formatter"
+          "description": "Enable/disable default YAML formatter",
+          "scope": "language-overridable"
         },
         "yaml.format.singleQuote": {
           "type": "boolean",
@@ -188,7 +189,8 @@
         "yaml.validate": {
           "type": "boolean",
           "default": true,
-          "description": "Enable/disable validation feature"
+          "description": "Enable/disable validation feature",
+          "scope": "language-overridable"
         },
         "yaml.hover": {
           "type": "boolean",


### PR DESCRIPTION
### What does this PR do?
Make `yaml.validate` and `yaml.format.enable` language-overridable

### What issues does this PR fix or reference?
https://github.com/redhat-developer/vscode-yaml/issues/1204#issuecomment-3930761456

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Manually