### PR TITLE
Fix filesystem watcher glob

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -132,7 +132,7 @@ export function startClient(
     ],
     synchronize: {
       // Notify the server about file changes to YAML and JSON files contained in the workspace
-      fileEvents: [workspace.createFileSystemWatcher('**/*.?(e)y?(a)ml'), workspace.createFileSystemWatcher('**/*.json')],
+      fileEvents: [workspace.createFileSystemWatcher('{**/*.json,**/*.yaml,**/*.eyaml,**/*.yml}')],
     },
     revealOutputChannelOn: RevealOutputChannelOn.Never,
     errorHandler: telemetryErrorHandler,


### PR DESCRIPTION
### What does this PR do?
The current glob for watching workspace file changes uses `?(e)` and `?(a)` to try and mean greadily accept `e` or `a` in the extension. Unfortuately, VS Code doesn't support this syntax, so changes in `.yaml` files in the workspace aren't reported to yaml-language-server.

As a result of this, if you have a JSON schema written in YAML, then any files that reference it won't be properly revalidated when you change it, and the cached version of the schema won't be invalidated properly, leading to incorrect completion results.

### What issues does this PR fix or reference?

See https://github.com/redhat-developer/yaml-language-server/issues/1134#issuecomment-4049069865

### Is it tested? How?
Manually
