### PR TITLE
Formatting support on web

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -21,6 +21,3 @@ CONTRIBUTING.md
 **/**.vsix
 **/**.tar.gz
 test-resources
-!node_modules/prettier/index.js
-!node_modules/prettier/third-party.js
-!node_modules/prettier/parser-yaml.js

--- a/smoke-test/smoke.test.ts
+++ b/smoke-test/smoke.test.ts
@@ -10,9 +10,11 @@ suite('Smoke test suite', function () {
 
   const SCHEMA_INSTANCE_NAME = 'references-schema.yaml';
   const THROUGH_SETTINGS_NAME = 'references-schema-settings.yaml';
+  const UNFORMATTED_NAME = 'unformatted.yaml';
 
   let schemaInstanceUri: URI;
   let throughSettingsUri: URI;
+  let unformattedUri: URI;
 
   this.beforeAll(async function () {
     const workspaceUri = vscode.workspace.workspaceFolders[0].uri;
@@ -21,6 +23,9 @@ suite('Smoke test suite', function () {
     });
     throughSettingsUri = workspaceUri.with({
       path: workspaceUri.path + (workspaceUri.path.endsWith('/') ? '' : '/') + THROUGH_SETTINGS_NAME,
+    });
+    unformattedUri = workspaceUri.with({
+      path: workspaceUri.path + (workspaceUri.path.endsWith('/') ? '' : '/') + UNFORMATTED_NAME,
     });
   });
 
@@ -42,5 +47,29 @@ suite('Smoke test suite', function () {
 
     assert.strictEqual(diagnostics.length, 1);
     assert.strictEqual(diagnostics[0].message, 'Value is below the minimum of 0.');
+  });
+
+  test('has right formatting', async function () {
+    const textDocument = await vscode.workspace.openTextDocument(unformattedUri);
+    await vscode.window.showTextDocument(textDocument);
+
+    // heavily borrowed from prettier's test suite
+    const edits = await vscode.commands.executeCommand<vscode.TextEdit[]>(
+      'vscode.executeFormatDocumentProvider',
+      textDocument.uri,
+      { tabSize: 2, insertSpaces: true }
+    );
+
+    if (edits && edits.length > 0) {
+      const workspaceEdit = new vscode.WorkspaceEdit();
+      workspaceEdit.set(textDocument.uri, edits);
+      await vscode.workspace.applyEdit(workspaceEdit);
+    }
+
+    const EXPECTED = `aaa:
+  bbb: hjkl
+`;
+
+    assert.strictEqual(textDocument.getText(), EXPECTED);
   });
 });

--- a/smoke-test/unformatted.yaml
+++ b/smoke-test/unformatted.yaml
@@ -1,0 +1,2 @@
+aaa:
+    bbb:  hjkl

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,7 +31,6 @@ const config = {
   devtool: 'source-map',
   externals: {
     vscode: 'commonjs vscode', // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
-    prettier: 'commonjs prettier',
   },
   resolve: {
     // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
@@ -136,7 +135,6 @@ const serverWeb = {
     mainFields: ['browser', 'module', 'main'],
     extensions: ['.ts', '.js'], // support ts-files and js-files
     alias: {
-      './services/yamlFormatter': path.resolve(__dirname, './build/polyfills/yamlFormatter.js'), // not supported for now. prettier can run in the web, but it's a bit more work.
       'vscode-json-languageservice/lib/umd': 'vscode-json-languageservice/lib/esm',
     },
     fallback: {


### PR DESCRIPTION
### What does this PR do?
We switched the formatter implementation of yaml-language-server to be based on eemeli/yaml instead of prettier,
since it can provide all the same functionality, and avoiding the extra dependency on prettier reduces the total size of the language server.

Using prettier to provide formatting support was also a blocker for getting the formatting to work in the web version of the extension, since prettier doesn't work well with bundlers.

This PR removes the shim that changed formatting on web to a NO-OP, since we should now be able to format properly on web.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
- [x] Integration tests on web