### PR TITLE
Permissive int and float syntax highlighting

### DIFF
--- a/syntaxes/yaml.tmLanguage.json
+++ b/syntaxes/yaml.tmLanguage.json
@@ -448,16 +448,10 @@
 							"name": "constant.numeric.float.yaml"
 						},
 						"5": {
-							"name": "constant.other.timestamp.yaml"
-						},
-						"6": {
-							"name": "constant.language.value.yaml"
-						},
-						"7": {
-							"name": "constant.language.merge.yaml"
+							"name": "keyword.operator.yaml"
 						}
 					},
-					"match": "(?x)\n                        (?x:\n                              (null|Null|NULL|~)\n                            | (y|Y|yes|Yes|YES|n|N|no|No|NO|true|True|TRUE|false|False|FALSE|on|On|ON|off|Off|OFF)\n                            | (\n                                (?:\n                                      [-+]? 0b [0-1_]+ # (base 2)\n                                    | [-+]? 0  [0-7_]+ # (base 8)\n                                    | [-+]? (?: 0|[1-9][0-9_]*) # (base 10)\n                                    | [-+]? 0x [0-9a-fA-F_]+ # (base 16)\n                                    | [-+]? [1-9] [0-9_]* (?: :[0-5]?[0-9])+ # (base 60)\n                                )\n                              )\n                            | (\n                                (?x:\n                                      [-+]? ( \\. [0-9]+ | [0-9]+ ( \\. [0-9]* )? ) ( [eE] [-+]? [0-9]+ )? # (base 10)\n                                    | [-+]? [0-9] [0-9_]* (?: :[0-5]?[0-9])+ \\. [0-9_]* # (base 60)\n                                    | [-+]? \\. (?: inf|Inf|INF) # (infinity)\n                                    |       \\. (?: nan|NaN|NAN) # (not a number)\n                                )\n                              )\n                            | (\n                                (?x:\n                                    \\d{4} - \\d{2} - \\d{2}           # (y-m-d)\n                                  | \\d{4}                           # (year)\n                                    - \\d{1,2}                       # (month)\n                                    - \\d{1,2}                       # (day)\n                                    (?: [Tt] | [ \\t]+) \\d{1,2}      # (hour)\n                                    : \\d{2}                         # (minute)\n                                    : \\d{2}                         # (second)\n                                    (?: \\.\\d*)?                     # (fraction)\n                                    (?:\n                                          (?:[ \\t]*) Z\n                                        | [-+] \\d{1,2} (?: :\\d{1,2})?\n                                    )?                              # (time zone)\n                                )\n                              )\n                            | (=)\n                            | (<<)\n                        )\n                        (?:\n                            (?=\n                                  \\s* $\n                                | \\s+ \\#\n                                | \\s* : (\\s|$)\n                                | \\s* : [\\[\\]{},]\n                                | \\s* [\\[\\]{},]\n                            )\n                        )\n                    "
+					"match": "(?x) (?x:(null|Null|NULL|~)  |  (y|Y|yes|Yes|YES|n|N|no|No|NO|true|True|TRUE|false|False|FALSE|on|On|ON|off|Off|OFF)  |  ((?:[-+]? [0-9]+) | (?:0o [0-7]+) | (?:0x [0-9a-fA-F]+) | (?:[-+]? [1-9] [0-9_]* (?: :[0-5]?[0-9])+))  |  ((?:[-+]? (?: \\. [0-9]+ | [0-9]+ (?: \\. [0-9]* )? ) (?: [eE] [-+]? [0-9]+ )?) | (?:[-+]? [0-9] [0-9_]* (?: :[0-5]?[0-9])+ \\. [0-9_]*) | (?:[-+]? (?: \\.inf | \\.Inf | \\.INF )) | (?:\\.nan | \\.NaN | \\.NAN) )  |  (<<) )     (?: (?= \\s* $ | \\s+ \\# | \\s* : (\\s|$) | \\s* : [\\[\\]{},] | \\s* [\\[\\]{},] ) )"
 				}
 			]
 		},
@@ -490,16 +484,10 @@
 							"name": "constant.numeric.float.yaml"
 						},
 						"5": {
-							"name": "constant.other.timestamp.yaml"
-						},
-						"6": {
-							"name": "constant.language.value.yaml"
-						},
-						"7": {
-							"name": "constant.language.merge.yaml"
+							"name": "keyword.operator.yaml"
 						}
 					},
-					"match": "(?x)\n                        (?x:\n                              (null|Null|NULL|~)\n                            | (y|Y|yes|Yes|YES|n|N|no|No|NO|true|True|TRUE|false|False|FALSE|on|On|ON|off|Off|OFF)\n                            | (\n                                (?:\n                                      [-+]? 0b [0-1_]+ # (base 2)\n                                    | [-+]? 0  [0-7_]+ # (base 8)\n                                    | [-+]? (?: 0|[1-9][0-9_]*) # (base 10)\n                                    | [-+]? 0x [0-9a-fA-F_]+ # (base 16)\n                                    | [-+]? [1-9] [0-9_]* (?: :[0-5]?[0-9])+ # (base 60)\n                                )\n                              )\n                            | (\n                                (?x:\n                                      [-+]? ( \\. [0-9]+ | [0-9]+ ( \\. [0-9]* )? ) ( [eE] [-+]? [0-9]+ )? # (base 10)\n                                    | [-+]? [0-9] [0-9_]* (?: :[0-5]?[0-9])+ \\. [0-9_]* # (base 60)\n                                    | [-+]? \\. (?: inf|Inf|INF) # (infinity)\n                                    |       \\. (?: nan|NaN|NAN) # (not a number)\n                                )\n                              )\n                            | (\n                                (?x:\n                                    \\d{4} - \\d{2} - \\d{2}           # (y-m-d)\n                                  | \\d{4}                           # (year)\n                                    - \\d{1,2}                       # (month)\n                                    - \\d{1,2}                       # (day)\n                                    (?: [Tt] | [ \\t]+) \\d{1,2}      # (hour)\n                                    : \\d{2}                         # (minute)\n                                    : \\d{2}                         # (second)\n                                    (?: \\.\\d*)?                     # (fraction)\n                                    (?:\n                                          (?:[ \\t]*) Z\n                                        | [-+] \\d{1,2} (?: :\\d{1,2})?\n                                    )?                              # (time zone)\n                                )\n                              )\n                            | (=)\n                            | (<<)\n                        )\n                        (?x:\n                            (?=\n                                  \\s* $\n                                | \\s+ \\#\n                                | \\s* : (\\s|$)\n                            )\n                        )\n                    "
+					"match": "(?x) (?x:(null|Null|NULL|~)  |  (y|Y|yes|Yes|YES|n|N|no|No|NO|true|True|TRUE|false|False|FALSE|on|On|ON|off|Off|OFF)  |  ((?:[-+]? [0-9]+) | (?:0o [0-7]+) | (?:0x [0-9a-fA-F]+) | (?:[-+]? [1-9] [0-9_]* (?: :[0-5]?[0-9])+))  |  ((?:[-+]? (?: \\. [0-9]+ | [0-9]+ (?: \\. [0-9]* )? ) (?: [eE] [-+]? [0-9]+ )?) | (?:[-+]? [0-9] [0-9_]* (?: :[0-5]?[0-9])+ \\. [0-9_]*) | (?:[-+]? (?: \\.inf | \\.Inf | \\.INF )) | (?:\\.nan | \\.NaN | \\.NAN) )  |  (<<) )     (?x: (?= \\s* $ | \\s+ \\# | \\s* : (\\s|$) ) )"
 				}
 			]
 		},


### PR DESCRIPTION
### What does this PR do?
- Clean up the regex used to syntax highlight integers, booleans, and floats
- Permit integers beginning with one or multiple `0`s
- ~~Broke syntax highlighting of `<<`~~ fixed
- `<<` is syntax highlighted as an operator instead of having no scope (this means it changes in some themes, such as Monokai)

### What issues does this PR fix or reference?
https://github.com/redhat-developer/vscode-yaml/issues/1190, https://github.com/redhat-developer/vscode-yaml/issues/1225

### Is it tested? How?
Manually
