### PR TITLE
Make showing schema source URI in hovers configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The following settings are supported:
 * `yaml.validate`: Enable/disable validation feature
 * `yaml.hover`: Enable/disable hover
 * `yaml.hoverAnchor`: Enable/disable hover feature for anchors
+* `yaml.hoverSchemaSource`: Enable/disable showing the schema source in hover tooltips
 * `yaml.completion`: Enable/disable autocompletion
 * `yaml.schemas`: Helps you associate schemas with files in a glob pattern
 * `yaml.schemaStore.enable`: When set to true, the YAML language server will pull in all available schemas from [JSON Schema Store](http://schemastore.org/)

--- a/package.json
+++ b/package.json
@@ -269,6 +269,11 @@
           "type": "boolean",
           "default": "true",
           "description": "Suggest additional extensions based on YAML usage."
+        },
+        "yaml.hoverSchemaSource": {
+          "type": "boolean",
+          "default": "true",
+          "description": "Enable/disable showing the schema source in hover tooltips"
         }
       }
     },


### PR DESCRIPTION
### What does this PR do?
Added the `yaml.hoverSchemaSource` configuration option to control whether the schema source is shown in hover tooltips. Defaults to `true`.

See https://github.com/redhat-developer/yaml-language-server/pull/1242

### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/yaml-language-server/issues/1120

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Tested manually