### PR TITLE
Revert "Adjust to switch of formatter implementation from prettier to yaml"

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -21,3 +21,6 @@ CONTRIBUTING.md
 **/**.vsix
 **/**.tar.gz
 test-resources
+!node_modules/prettier/index.js
+!node_modules/prettier/third-party.js
+!node_modules/prettier/parser-yaml.js

--- a/smoke-test/smoke.test.ts
+++ b/smoke-test/smoke.test.ts
@@ -10,11 +10,9 @@ describe('Smoke test suite', function () {
 
   const SCHEMA_INSTANCE_NAME = 'references-schema.yaml';
   const THROUGH_SETTINGS_NAME = 'references-schema-settings.yaml';
-  const UNFORMATTED_NAME = 'unformatted.yaml';
 
   let schemaInstanceUri: URI;
   let throughSettingsUri: URI;
-  let unformattedUri: URI;
 
   before(async function () {
     if (vscode.workspace.workspaceFolders === undefined) {
@@ -26,9 +24,6 @@ describe('Smoke test suite', function () {
     });
     throughSettingsUri = workspaceUri.with({
       path: workspaceUri.path + (workspaceUri.path.endsWith('/') ? '' : '/') + THROUGH_SETTINGS_NAME,
-    });
-    unformattedUri = workspaceUri.with({
-      path: workspaceUri.path + (workspaceUri.path.endsWith('/') ? '' : '/') + UNFORMATTED_NAME,
     });
   });
 
@@ -50,29 +45,5 @@ describe('Smoke test suite', function () {
 
     assert.strictEqual(diagnostics.length, 1);
     assert.strictEqual(diagnostics[0].message, 'Value is below the minimum of 0.');
-  });
-
-  it('has right formatting', async function () {
-    const textDocument = await vscode.workspace.openTextDocument(unformattedUri);
-    await vscode.window.showTextDocument(textDocument);
-
-    // heavily borrowed from prettier's test suite
-    const edits = await vscode.commands.executeCommand<vscode.TextEdit[]>(
-      'vscode.executeFormatDocumentProvider',
-      textDocument.uri,
-      { tabSize: 2, insertSpaces: true }
-    );
-
-    if (edits && edits.length > 0) {
-      const workspaceEdit = new vscode.WorkspaceEdit();
-      workspaceEdit.set(textDocument.uri, edits);
-      await vscode.workspace.applyEdit(workspaceEdit);
-    }
-
-    const EXPECTED = `aaa:
-  bbb: hjkl
-`;
-
-    assert.strictEqual(textDocument.getText(), EXPECTED);
   });
 });

--- a/smoke-test/unformatted.yaml
+++ b/smoke-test/unformatted.yaml
@@ -1,2 +1,0 @@
-aaa:
-    bbb:  hjkl

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,6 +31,7 @@ const config = {
   devtool: 'source-map',
   externals: {
     vscode: 'commonjs vscode', // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
+    prettier: 'commonjs prettier',
   },
   resolve: {
     // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
@@ -135,6 +136,7 @@ const serverWeb = {
     mainFields: ['browser', 'module', 'main'],
     extensions: ['.ts', '.js'], // support ts-files and js-files
     alias: {
+      './services/yamlFormatter': path.resolve(__dirname, './build/polyfills/yamlFormatter.js'), // not supported for now. prettier can run in the web, but it's a bit more work.
       'vscode-json-languageservice/lib/umd': 'vscode-json-languageservice/lib/esm',
     },
     fallback: {


### PR DESCRIPTION
### What does this PR do?
This reverts commit 6dc890635a639de552a937d3b11902d69b8f8bb6.

We reverted the change that replaced prettier with a different formatter implementation due to bugs in the implementation, so we can no longer support formatting on web.

### What issues does this PR fix or reference?
https://github.com/redhat-developer/yaml-language-server/pull/1240

### Is it tested? How?
No
