### PR TITLE
Fix default value of two extension settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -267,12 +267,12 @@
         },
         "yaml.extension.recommendations": {
           "type": "boolean",
-          "default": "true",
+          "default": true,
           "description": "Suggest additional extensions based on YAML usage."
         },
         "yaml.hoverSchemaSource": {
           "type": "boolean",
-          "default": "true",
+          "default": true,
           "description": "Enable/disable showing the schema source in hover tooltips"
         }
       }


### PR DESCRIPTION
The type of those properties is boolean so the default should be literal boolean and not a string.

### What does this PR do?

fix extension schema definition

### What issues does this PR fix or reference?

No issue

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

validating my settings (in sublime text) against schema)