### PR TITLE
Add setting to disable automatic schema detection for matching YAML files and add "No JSON Schema" to schema picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
           },
           "markdownDescription": "Associate schemas to YAML files in the current workspace. The expected value of this configuration option is a string to string map:\n- **Key**: The path or URL of the schema to use\n- **Value**: A glob pattern or list of glob patterns specifying which files the schema should be used on"
         },
-        "yaml.schemaDetectionDisableFor": {
+        "yaml.disableSchemaDetection": {
           "anyOf": [
             {
               "type": "string"
@@ -153,7 +153,7 @@
             }
           ],
           "default": [],
-          "markdownDescription": "Disable automatically detected schemas for YAML files matching the configured glob pattern or glob patterns. The expected value is a glob pattern or list of glob patterns. Schemas explicitly configured with `yaml.schemas` or with a modeline still apply."
+          "markdownDescription": "Disable schema detection for YAML files matching the configured glob pattern or glob patterns. The expected value is a glob pattern or list of glob patterns. Modelines still apply."
         },
         "yaml.kubernetesCRDStore.enable": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -140,6 +140,21 @@
           },
           "markdownDescription": "Associate schemas to YAML files in the current workspace. The expected value of this configuration option is a string to string map:\n- **Key**: The path or URL of the schema to use\n- **Value**: A glob pattern or list of glob patterns specifying which files the schema should be used on"
         },
+        "yaml.schemaDetectionDisableFor": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "default": [],
+          "markdownDescription": "Disable automatically detected schemas for YAML files matching the configured glob pattern or glob patterns. The expected value is a glob pattern or list of glob patterns. Schemas explicitly configured with `yaml.schemas` or with a modeline still apply."
+        },
         "yaml.kubernetesCRDStore.enable": {
           "type": "boolean",
           "description": "Enable/disable validation of Kubernetes custom resources using schemas from well-known Custom Resource Definitions (CRDs)",

--- a/src/schema-status-bar-item.ts
+++ b/src/schema-status-bar-item.ts
@@ -31,6 +31,7 @@ interface MatchingJSONSchema extends JSONSchema {
 
 interface SchemaItem extends QuickPickItem {
   schema?: MatchingJSONSchema;
+  disableSchemaDetection?: boolean;
 }
 
 interface SchemaVersionItem extends QuickPickItem {
@@ -50,6 +51,7 @@ let client: CommonLanguageClient;
 let versionSelection: SchemaItem = undefined;
 
 const selectVersionLabel = 'Select Different Version';
+const noSchemaLabel = 'No JSON Schema';
 
 export function createJSONSchemaStatusBarItem(context: ExtensionContext, languageclient: CommonLanguageClient): void {
   if (statusBarItem) {
@@ -73,10 +75,11 @@ export function createJSONSchemaStatusBarItem(context: ExtensionContext, languag
 async function updateStatusBar(editor: TextEditor): Promise<void> {
   if (editor && editor.document.languageId === 'yaml') {
     versionSelection = undefined;
+    const fileUri = editor.document.uri.toString();
     // get schema info there
-    const schema = await client.sendRequest(getSchemaRequestType, editor.document.uri.toString());
+    const schema = await client.sendRequest(getSchemaRequestType, fileUri);
     if (!schema || schema.length === 0) {
-      statusBarItem.text = 'No JSON Schema';
+      statusBarItem.text = noSchemaLabel;
       statusBarItem.tooltip = 'Select JSON Schema';
       statusBarItem.backgroundColor = undefined;
     } else if (schema.length === 1) {
@@ -85,7 +88,7 @@ async function updateStatusBar(editor: TextEditor): Promise<void> {
       if (schema[0].versions) {
         version = findUsedVersion(schema[0].versions, schema[0].uri);
       } else {
-        const schemas = await client.sendRequest(getJSONSchemasRequestType, window.activeTextEditor.document.uri.toString());
+        const schemas = await client.sendRequest(getJSONSchemasRequestType, fileUri);
         let versionSchema: JSONSchema;
         const schemaStoreItem = findSchemaStoreItem(schemas, schema[0].uri);
         if (schemaStoreItem) {
@@ -113,7 +116,8 @@ async function updateStatusBar(editor: TextEditor): Promise<void> {
 }
 
 async function showSchemaSelection(): Promise<void> {
-  const schemas = await client.sendRequest(getJSONSchemasRequestType, window.activeTextEditor.document.uri.toString());
+  const fileUri = window.activeTextEditor.document.uri.toString();
+  const schemas = await client.sendRequest(getJSONSchemasRequestType, fileUri);
   const schemasPick = window.createQuickPick<SchemaItem>();
   let pickItems: SchemaItem[] = [];
 
@@ -151,6 +155,12 @@ async function showSchemaSelection(): Promise<void> {
     return a.label.localeCompare(b.label);
   });
 
+  pickItems.unshift({
+    label: noSchemaLabel,
+    alwaysShow: true,
+    disableSchemaDetection: true,
+  });
+
   schemasPick.items = pickItems;
   schemasPick.placeholder = 'Search JSON schema';
   schemasPick.title = 'Select JSON schema';
@@ -160,9 +170,11 @@ async function showSchemaSelection(): Promise<void> {
     try {
       if (selection.length > 0) {
         if (selection[0].label === selectVersionLabel) {
-          handleSchemaVersionSelection(selection[0].schema);
+          handleSchemaVersionSelection(selection[0].schema, fileUri);
+        } else if (selection[0].disableSchemaDetection) {
+          writeDisableSchemaDetectionMapping(fileUri);
         } else if (selection[0].schema) {
-          writeSchemaUriMapping(selection[0].schema.uri);
+          writeSchemaUriMapping(selection[0].schema.uri, fileUri);
         }
       }
     } catch (err) {
@@ -192,6 +204,34 @@ function deleteExistingFilePattern(settings: Record<string, unknown>, fileUri: s
   return settings;
 }
 
+function removeFilePatternFromSetting(setting: unknown, fileUri: string): string | string[] {
+  if (Array.isArray(setting)) {
+    return setting.filter((value): value is string => typeof value === 'string' && value !== fileUri);
+  }
+
+  if (setting === fileUri) {
+    return [];
+  }
+
+  return typeof setting === 'string' ? setting : [];
+}
+
+function addFilePatternToSetting(setting: unknown, fileUri: string): string | string[] {
+  if (Array.isArray(setting)) {
+    const filePatterns = setting.filter((value): value is string => typeof value === 'string');
+    if (!filePatterns.includes(fileUri)) {
+      filePatterns.push(fileUri);
+    }
+    return filePatterns;
+  }
+
+  if (typeof setting === 'string') {
+    return setting === fileUri ? setting : [setting, fileUri];
+  }
+
+  return [fileUri];
+}
+
 function createSelectVersionItem(version: string, schema: MatchingJSONSchema): SchemaItem {
   return {
     label: selectVersionLabel,
@@ -212,9 +252,11 @@ function findSchemaStoreItem(schemas: JSONSchema[], url: string): [string, JSONS
   }
 }
 
-function writeSchemaUriMapping(schemaUrl: string): void {
-  const settings: Record<string, unknown> = workspace.getConfiguration('yaml').get('schemas');
-  const fileUri = window.activeTextEditor.document.uri.toString();
+function writeSchemaUriMapping(schemaUrl: string, fileUri: string): void {
+  const yamlConfiguration = workspace.getConfiguration('yaml');
+  const settings: Record<string, unknown> = yamlConfiguration.get('schemas');
+  const disableSchemaDetection = yamlConfiguration.get('disableSchemaDetection');
+  yamlConfiguration.update('disableSchemaDetection', removeFilePatternFromSetting(disableSchemaDetection, fileUri));
   const newSettings = Object.assign({}, settings);
   deleteExistingFilePattern(newSettings, fileUri);
   const schemaSettings = newSettings[schemaUrl];
@@ -227,10 +269,16 @@ function writeSchemaUriMapping(schemaUrl: string): void {
   } else {
     newSettings[schemaUrl] = fileUri;
   }
-  workspace.getConfiguration('yaml').update('schemas', newSettings);
+  yamlConfiguration.update('schemas', newSettings);
 }
 
-function handleSchemaVersionSelection(schema: MatchingJSONSchema): void {
+function writeDisableSchemaDetectionMapping(fileUri: string): void {
+  const yamlConfiguration = workspace.getConfiguration('yaml');
+  const disableSchemaDetection = yamlConfiguration.get('disableSchemaDetection');
+  yamlConfiguration.update('disableSchemaDetection', addFilePatternToSetting(disableSchemaDetection, fileUri));
+}
+
+function handleSchemaVersionSelection(schema: MatchingJSONSchema, fileUri: string): void {
   const versionPick = window.createQuickPick<SchemaVersionItem>();
   const versionItems: SchemaVersionItem[] = [];
   const usedVersion = findUsedVersion(schema.versions, schema.uri);
@@ -249,7 +297,7 @@ function handleSchemaVersionSelection(schema: MatchingJSONSchema): void {
 
   versionPick.onDidChangeSelection((items) => {
     if (items && items.length === 1) {
-      writeSchemaUriMapping(items[0].url);
+      writeSchemaUriMapping(items[0].url, fileUri);
     }
     versionPick.hide();
   });

--- a/test/json-schema-selection.test.ts
+++ b/test/json-schema-selection.test.ts
@@ -15,19 +15,27 @@ import * as jsonStatusBar from '../src/schema-status-bar-item';
 const expect = chai.expect;
 chai.use(sinonChai);
 
+interface TestSchemaItem extends vscode.QuickPickItem {
+  schema?: unknown;
+}
+
 describe('Status bar should work in multiple different scenarios', () => {
   const sandbox = sinon.createSandbox();
   let clcStub: sinon.SinonStubbedInstance<TestLanguageClient>;
   let registerCommandStub: sinon.SinonStub;
   let createStatusBarItemStub: sinon.SinonStub;
   let onDidChangeActiveTextEditorStub: sinon.SinonStub;
+  let createQuickPickStub: sinon.SinonStub;
+  let activeTextEditor: vscode.TextEditor | undefined;
 
   beforeEach(() => {
     clcStub = sandbox.stub(new TestLanguageClient());
     registerCommandStub = sandbox.stub(vscode.commands, 'registerCommand');
     createStatusBarItemStub = sandbox.stub(vscode.window, 'createStatusBarItem');
+    createQuickPickStub = sandbox.stub(vscode.window, 'createQuickPick');
     onDidChangeActiveTextEditorStub = sandbox.stub(vscode.window, 'onDidChangeActiveTextEditor');
-    sandbox.stub(vscode.window, 'activeTextEditor').returns(undefined);
+    activeTextEditor = undefined;
+    sandbox.stub(vscode.window, 'activeTextEditor').get(() => activeTextEditor);
     sandbox.stub(jsonStatusBar, 'statusBarItem').returns(undefined);
   });
 
@@ -154,4 +162,116 @@ describe('Status bar should work in multiple different scenarios', () => {
     expect(statusBar.backgroundColor).to.be.undefined;
     expect(statusBar.show).calledOnce;
   });
+
+  it('Should include No JSON Schema in schema selection', async () => {
+    const context: vscode.ExtensionContext = {
+      subscriptions: [],
+    } as vscode.ExtensionContext;
+    const statusBar = ({ show: sandbox.stub(), hide: sandbox.stub() } as unknown) as vscode.StatusBarItem;
+    const quickPick = createQuickPickStubValue<TestSchemaItem>();
+    createStatusBarItemStub.returns(statusBar);
+    createQuickPickStub.returns(quickPick);
+    clcStub.sendRequest.resolves([{ uri: 'https://foo.com/bar.json', name: 'bar schema' }]);
+    activeTextEditor = ({
+      document: { languageId: 'yaml', uri: vscode.Uri.parse('/foo.yaml') },
+    } as unknown) as vscode.TextEditor;
+
+    createJSONSchemaStatusBarItem(context, (clcStub as unknown) as CommonLanguageClient);
+    const command = registerCommandStub.firstCall.args[1];
+    await command();
+
+    expect(quickPick.items[0].label).to.equal('No JSON Schema');
+    expect(quickPick.show).calledOnce;
+  });
+
+  it('Should write disableSchemaDetection when No JSON Schema is selected', async () => {
+    const context: vscode.ExtensionContext = {
+      subscriptions: [],
+    } as vscode.ExtensionContext;
+    const statusBar = ({ show: sandbox.stub(), hide: sandbox.stub() } as unknown) as vscode.StatusBarItem;
+    const quickPick = createQuickPickStubValue<TestSchemaItem>();
+    const update = sandbox.stub();
+    createStatusBarItemStub.returns(statusBar);
+    createQuickPickStub.returns(quickPick);
+    clcStub.sendRequest.resolves([{ uri: 'https://foo.com/bar.json', name: 'bar schema' }]);
+    activeTextEditor = ({
+      document: { languageId: 'yaml', uri: vscode.Uri.parse('/foo.yaml') },
+    } as unknown) as vscode.TextEditor;
+    sandbox
+      .stub(vscode.workspace, 'getConfiguration')
+      .withArgs('yaml')
+      .returns(({
+        get: sandbox.stub().withArgs('disableSchemaDetection').returns([]),
+        update,
+      } as unknown) as vscode.WorkspaceConfiguration);
+
+    createJSONSchemaStatusBarItem(context, (clcStub as unknown) as CommonLanguageClient);
+    const command = registerCommandStub.firstCall.args[1];
+    await command();
+    quickPick.select([quickPick.items[0]]);
+
+    expect(update).calledWith('disableSchemaDetection', ['file:///foo.yaml']);
+    expect(quickPick.hide).calledOnce;
+  });
+
+  it('Should clear disableSchemaDetection when a schema is selected', async () => {
+    const context: vscode.ExtensionContext = {
+      subscriptions: [],
+    } as vscode.ExtensionContext;
+    const statusBar = ({ show: sandbox.stub(), hide: sandbox.stub() } as unknown) as vscode.StatusBarItem;
+    const quickPick = createQuickPickStubValue<TestSchemaItem>();
+    const update = sandbox.stub();
+    const get = sandbox.stub();
+    get.withArgs('disableSchemaDetection').returns(['file:///foo.yaml', 'file:///other.yaml']);
+    get.withArgs('schemas').returns({});
+    createStatusBarItemStub.returns(statusBar);
+    createQuickPickStub.returns(quickPick);
+    clcStub.sendRequest.resolves([{ uri: 'https://foo.com/bar.json', name: 'bar schema' }]);
+    activeTextEditor = ({
+      document: { languageId: 'yaml', uri: vscode.Uri.parse('/foo.yaml') },
+    } as unknown) as vscode.TextEditor;
+    sandbox
+      .stub(vscode.workspace, 'getConfiguration')
+      .withArgs('yaml')
+      .returns(({
+        get,
+        update,
+      } as unknown) as vscode.WorkspaceConfiguration);
+
+    createJSONSchemaStatusBarItem(context, (clcStub as unknown) as CommonLanguageClient);
+    const command = registerCommandStub.firstCall.args[1];
+    await command();
+    const schemaItem = quickPick.items.find((item) => item.schema);
+    expect(schemaItem).to.exist;
+    quickPick.select([schemaItem as TestSchemaItem]);
+
+    expect(update).calledWith('disableSchemaDetection', ['file:///other.yaml']);
+    expect(update).calledWith('schemas', { 'https://foo.com/bar.json': 'file:///foo.yaml' });
+    expect(quickPick.hide).calledOnce;
+  });
 });
+
+function createQuickPickStubValue<T extends vscode.QuickPickItem>(): vscode.QuickPick<T> & { select: (items: T[]) => void } {
+  let selectionHandler: (items: readonly T[]) => void;
+  let hideHandler: () => void;
+  const quickPick = {
+    items: [] as readonly T[],
+    placeholder: '',
+    title: '',
+    show: sinon.stub(),
+    hide: sinon.stub(),
+    dispose: sinon.stub(),
+    onDidHide: sinon.stub(),
+    onDidChangeSelection: sinon.stub().callsFake((handler: (items: readonly T[]) => void) => {
+      selectionHandler = handler;
+      return { dispose: sinon.stub() };
+    }),
+    select: (items: T[]) => selectionHandler(items),
+  };
+  quickPick.hide.callsFake(() => hideHandler?.());
+  quickPick.onDidHide.callsFake((handler: () => void) => {
+    hideHandler = handler;
+    return { dispose: sinon.stub() };
+  });
+  return (quickPick as unknown) as vscode.QuickPick<T> & { select: (items: T[]) => void };
+}


### PR DESCRIPTION
### What does this PR do?
- Added setting to disable automatic schema detection for matching YAML files (See https://github.com/redhat-developer/yaml-language-server/pull/1251)
- Made "No JSON Schema" option selectable in schema picker from the status bar

### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/vscode-yaml/issues/245
Fixes https://github.com/redhat-developer/vscode-yaml/issues/991

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
- [x] New automated tests
- [x] Manual testing