### PR TITLE
Fix StackOverflow when selecting a schema for a YAML file that matches multiple schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ It is possible to specify a yaml schema using a modeline. Schema url can be a re
 
 ### Associating a schema to a glob pattern via yaml.schemas:
 
-`yaml.schemas`  applies a schema to a file. In other words, the schema (placed on the left) is applied to the glob pattern on the right. Your schema can be local or online. Your schema must be a relative path and not an absolute path. The entrance point for `yaml.schemas` is a location in [user and workspace settings](https://code.visualstudio.com/docs/getstarted/settings#_creating-user-and-workspace-settings)
+`yaml.schemas`  applies a schema to a file. In other words, the schema (placed on the left) is applied to the glob pattern on the right. Your schema can be local or online. Local schema paths can be relative to the project root or absolute paths. The entrance point for `yaml.schemas` is a location in [user and workspace settings](https://code.visualstudio.com/docs/getstarted/settings#_creating-user-and-workspace-settings)
 
 When associating a schema it should follow the format below
 ```JSON

--- a/src/schema-status-bar-item.ts
+++ b/src/schema-status-bar-item.ts
@@ -12,6 +12,7 @@ import {
   QuickPickItem,
   ThemeColor,
   workspace,
+  Uri,
 } from 'vscode';
 import { CommonLanguageClient, RequestType } from 'vscode-languageclient/node';
 
@@ -185,17 +186,36 @@ async function showSchemaSelection(): Promise<void> {
   schemasPick.show();
 }
 
-function deleteExistingFilePattern(settings: Record<string, unknown>, fileUri: string): unknown {
+function getFilePatternCandidates(fileUri: string): string[] {
+  const candidates = new Set<string>([fileUri]);
+  try {
+    const uri = Uri.parse(fileUri);
+    if (uri.fsPath) {
+      candidates.add(uri.fsPath);
+      candidates.add(workspace.asRelativePath(uri, false));
+    }
+  } catch {
+  }
+  return Array.from(candidates).filter(Boolean);
+}
+
+function deleteExistingFilePattern(settings: Record<string, unknown>, filePatterns: string[]): unknown {
   for (const key in settings) {
     if (Object.prototype.hasOwnProperty.call(settings, key)) {
       const element = settings[key];
 
       if (Array.isArray(element)) {
-        const filePatterns = element.filter((val) => val !== fileUri);
-        settings[key] = filePatterns;
+        const remainingFilePatterns = element.filter(
+          (val): val is string => typeof val === 'string' && !filePatterns.includes(val)
+        );
+        if (remainingFilePatterns.length === 0) {
+          delete settings[key];
+        } else {
+          settings[key] = remainingFilePatterns;
+        }
       }
 
-      if (element === fileUri) {
+      if (typeof element === 'string' && filePatterns.includes(element)) {
         delete settings[key];
       }
     }
@@ -204,12 +224,12 @@ function deleteExistingFilePattern(settings: Record<string, unknown>, fileUri: s
   return settings;
 }
 
-function removeFilePatternFromSetting(setting: unknown, fileUri: string): string | string[] {
+function removeFilePatternFromSetting(setting: unknown, filePatterns: string[]): string | string[] {
   if (Array.isArray(setting)) {
-    return setting.filter((value): value is string => typeof value === 'string' && value !== fileUri);
+    return setting.filter((value): value is string => typeof value === 'string' && !filePatterns.includes(value));
   }
 
-  if (setting === fileUri) {
+  if (typeof setting === 'string' && filePatterns.includes(setting)) {
     return [];
   }
 
@@ -256,9 +276,10 @@ function writeSchemaUriMapping(schemaUrl: string, fileUri: string): void {
   const yamlConfiguration = workspace.getConfiguration('yaml');
   const settings: Record<string, unknown> = yamlConfiguration.get('schemas');
   const disableSchemaDetection = yamlConfiguration.get('disableSchemaDetection');
-  yamlConfiguration.update('disableSchemaDetection', removeFilePatternFromSetting(disableSchemaDetection, fileUri));
+  const filePatterns = getFilePatternCandidates(fileUri);
+  yamlConfiguration.update('disableSchemaDetection', removeFilePatternFromSetting(disableSchemaDetection, filePatterns));
   const newSettings = Object.assign({}, settings);
-  deleteExistingFilePattern(newSettings, fileUri);
+  deleteExistingFilePattern(newSettings, filePatterns);
   const schemaSettings = newSettings[schemaUrl];
   if (schemaSettings) {
     if (Array.isArray(schemaSettings)) {

--- a/src/schema-status-bar-item.ts
+++ b/src/schema-status-bar-item.ts
@@ -168,9 +168,21 @@ async function showSchemaSelection(): Promise<void> {
   const selectedSchemaItems = pickItems.filter((item) => item.schema?.usedForCurrentFile);
   schemasPick.selectedItems =
     selectedSchemaItems.length > 0 && !isSchemaDetectionDisabled(fileUri) ? selectedSchemaItems : [noSchemaItem];
+  let previousSelectedItems = schemasPick.selectedItems;
   schemasPick.placeholder = 'Search JSON schema';
   schemasPick.title = 'Select JSON schemas';
   schemasPick.onDidHide(() => schemasPick.dispose());
+  schemasPick.onDidChangeSelection((items) => {
+    const selectedSchemaItems = items.filter((item) => item.schema);
+    const hasNoSchemaItem = items.some((item) => item.disableSchemaDetection);
+    if (items.length === 0) {
+      schemasPick.selectedItems = [noSchemaItem];
+    } else if (hasNoSchemaItem && selectedSchemaItems.length > 0) {
+      const previousHadNoSchemaItem = previousSelectedItems.some((item) => item.disableSchemaDetection);
+      schemasPick.selectedItems = previousHadNoSchemaItem ? selectedSchemaItems : [noSchemaItem];
+    }
+    previousSelectedItems = schemasPick.selectedItems;
+  });
   schemasPick.onDidTriggerItemButton((event) => {
     if (event.button === selectSchemaVersionButton && event.item.schema?.versions) {
       const selectedSchemaUris = schemasPick.selectedItems.flatMap((item) => (item.schema ? [item.schema.uri] : []));

--- a/src/schema-status-bar-item.ts
+++ b/src/schema-status-bar-item.ts
@@ -195,6 +195,7 @@ function getFilePatternCandidates(fileUri: string): string[] {
       candidates.add(workspace.asRelativePath(uri, false));
     }
   } catch {
+    // ignore
   }
   return Array.from(candidates).filter(Boolean);
 }

--- a/src/schema-status-bar-item.ts
+++ b/src/schema-status-bar-item.ts
@@ -10,7 +10,7 @@ import {
   TextEditor,
   StatusBarItem,
   QuickPickItem,
-  ThemeColor,
+  ThemeIcon,
   workspace,
   Uri,
 } from 'vscode';
@@ -49,10 +49,12 @@ const getSchemaRequestType: RequestType<FileUri, JSONSchema[], {}> = new Request
 export let statusBarItem: StatusBarItem;
 
 let client: CommonLanguageClient;
-let versionSelection: SchemaItem = undefined;
 
-const selectVersionLabel = 'Select Different Version';
 const noSchemaLabel = 'No JSON Schema';
+const selectSchemaVersionButton = {
+  iconPath: new ThemeIcon('versions'),
+  tooltip: 'Select schema version',
+};
 
 export function createJSONSchemaStatusBarItem(context: ExtensionContext, languageclient: CommonLanguageClient): void {
   if (statusBarItem) {
@@ -69,45 +71,49 @@ export function createJSONSchemaStatusBarItem(context: ExtensionContext, languag
   context.subscriptions.push(statusBarItem);
 
   context.subscriptions.push(window.onDidChangeActiveTextEditor(updateStatusBar));
+  context.subscriptions.push(
+    workspace.onDidChangeTextDocument((event) => {
+      const editor = window.activeTextEditor;
+      if (
+        editor?.document.languageId === 'yaml' &&
+        editor.document.uri.toString() === event.document.uri.toString() &&
+        event.contentChanges?.some((change) => /#\s*yaml-language-server:\s*\$schema=/.test(change.text))
+      ) {
+        updateStatusBar(editor);
+      }
+    })
+  );
 
   updateStatusBar(window.activeTextEditor);
 }
 
 async function updateStatusBar(editor: TextEditor): Promise<void> {
   if (editor && editor.document.languageId === 'yaml') {
-    versionSelection = undefined;
     const fileUri = editor.document.uri.toString();
     // get schema info there
     const schema = await client.sendRequest(getSchemaRequestType, fileUri);
     if (!schema || schema.length === 0) {
       statusBarItem.text = noSchemaLabel;
-      statusBarItem.tooltip = 'Select JSON Schema';
-      statusBarItem.backgroundColor = undefined;
+      statusBarItem.tooltip = 'Select JSON Schemas';
     } else if (schema.length === 1) {
+      statusBarItem.tooltip = 'Select JSON Schemas';
       statusBarItem.text = schema[0].name ?? schema[0].uri;
       let version;
       if (schema[0].versions) {
         version = findUsedVersion(schema[0].versions, schema[0].uri);
       } else {
         const schemas = await client.sendRequest(getJSONSchemasRequestType, fileUri);
-        let versionSchema: JSONSchema;
         const schemaStoreItem = findSchemaStoreItem(schemas, schema[0].uri);
         if (schemaStoreItem) {
-          [version, versionSchema] = schemaStoreItem;
-          (versionSchema as MatchingJSONSchema).usedForCurrentFile = true;
-          versionSchema.uri = schema[0].uri;
-          versionSelection = createSelectVersionItem(version, versionSchema as MatchingJSONSchema);
+          version = schemaStoreItem[0];
         }
       }
       if (version && !statusBarItem.text.includes(version)) {
         statusBarItem.text += `(${version})`;
       }
-      statusBarItem.tooltip = 'Select JSON Schema';
-      statusBarItem.backgroundColor = undefined;
     } else {
-      statusBarItem.text = 'Multiple JSON Schemas...';
-      statusBarItem.tooltip = 'Multiple JSON Schema used to validate this file, click to select one';
-      statusBarItem.backgroundColor = new ThemeColor('statusBarItem.warningBackground');
+      statusBarItem.text = 'Multiple JSON Schemas';
+      statusBarItem.tooltip = `Validated using ${schema.length} JSON schemas:\n${schema.map((s) => s.name ?? s.uri).join('\n')}`;
     }
 
     statusBarItem.show();
@@ -123,21 +129,15 @@ async function showSchemaSelection(): Promise<void> {
   let pickItems: SchemaItem[] = [];
 
   for (const val of schemas) {
-    if (val.usedForCurrentFile && val.versions) {
-      const item = createSelectVersionItem(findUsedVersion(val.versions, val.uri), val);
-      pickItems.unshift(item);
-    }
     const item = {
       label: val.name ?? val.uri,
       description: val.description,
       detail: val.usedForCurrentFile ? 'Used for current file$(check)' : '',
       alwaysShow: val.usedForCurrentFile,
+      buttons: val.versions ? [selectSchemaVersionButton] : undefined,
       schema: val,
     };
     pickItems.push(item);
-  }
-  if (versionSelection) {
-    pickItems.unshift(versionSelection);
   }
 
   pickItems = pickItems.sort((a, b) => {
@@ -156,26 +156,39 @@ async function showSchemaSelection(): Promise<void> {
     return a.label.localeCompare(b.label);
   });
 
-  pickItems.unshift({
+  const noSchemaItem: SchemaItem = {
     label: noSchemaLabel,
     alwaysShow: true,
     disableSchemaDetection: true,
-  });
+  };
+  pickItems.unshift(noSchemaItem);
 
   schemasPick.items = pickItems;
+  schemasPick.canSelectMany = true;
+  const selectedSchemaItems = pickItems.filter((item) => item.schema?.usedForCurrentFile);
+  schemasPick.selectedItems =
+    selectedSchemaItems.length > 0 && !isSchemaDetectionDisabled(fileUri) ? selectedSchemaItems : [noSchemaItem];
   schemasPick.placeholder = 'Search JSON schema';
-  schemasPick.title = 'Select JSON schema';
+  schemasPick.title = 'Select JSON schemas';
   schemasPick.onDidHide(() => schemasPick.dispose());
+  schemasPick.onDidTriggerItemButton((event) => {
+    if (event.button === selectSchemaVersionButton && event.item.schema?.versions) {
+      const selectedSchemaUris = schemasPick.selectedItems.flatMap((item) => (item.schema ? [item.schema.uri] : []));
+      schemasPick.hide();
+      handleSchemaVersionSelection(event.item.schema, fileUri, selectedSchemaUris);
+    }
+  });
 
-  schemasPick.onDidChangeSelection((selection) => {
+  schemasPick.onDidAccept(async () => {
     try {
-      if (selection.length > 0) {
-        if (selection[0].label === selectVersionLabel) {
-          handleSchemaVersionSelection(selection[0].schema, fileUri);
-        } else if (selection[0].disableSchemaDetection) {
-          writeDisableSchemaDetectionMapping(fileUri);
-        } else if (selection[0].schema) {
-          writeSchemaUriMapping(selection[0].schema.uri, fileUri);
+      if (schemasPick.selectedItems.length === 0 || schemasPick.selectedItems.some((item) => item.disableSchemaDetection)) {
+        await writeDisableSchemaDetectionMapping(fileUri);
+      } else {
+        const schemaUrls = schemasPick.selectedItems.flatMap((item) => (item.schema ? [item.schema.uri] : []));
+        if (schemaUrls.length === 0) {
+          await writeDisableSchemaDetectionMapping(fileUri);
+        } else {
+          await writeSchemaUriMappings(schemaUrls, fileUri);
         }
       }
     } catch (err) {
@@ -198,6 +211,15 @@ function getFilePatternCandidates(fileUri: string): string[] {
     // ignore
   }
   return Array.from(candidates).filter(Boolean);
+}
+
+function isSchemaDetectionDisabled(fileUri: string): boolean {
+  const disableSchemaDetection = workspace.getConfiguration('yaml').get('disableSchemaDetection');
+  const filePatterns = getFilePatternCandidates(fileUri);
+  if (Array.isArray(disableSchemaDetection)) {
+    return disableSchemaDetection.some((value) => typeof value === 'string' && filePatterns.includes(value));
+  }
+  return typeof disableSchemaDetection === 'string' && filePatterns.includes(disableSchemaDetection);
 }
 
 function deleteExistingFilePattern(settings: Record<string, unknown>, filePatterns: string[]): unknown {
@@ -253,14 +275,6 @@ function addFilePatternToSetting(setting: unknown, fileUri: string): string | st
   return [fileUri];
 }
 
-function createSelectVersionItem(version: string, schema: MatchingJSONSchema): SchemaItem {
-  return {
-    label: selectVersionLabel,
-    detail: `Current: ${version}`,
-    alwaysShow: true,
-    schema: schema,
-  };
-}
 function findSchemaStoreItem(schemas: JSONSchema[], url: string): [string, JSONSchema] | undefined {
   for (const schema of schemas) {
     if (schema.versions) {
@@ -273,34 +287,41 @@ function findSchemaStoreItem(schemas: JSONSchema[], url: string): [string, JSONS
   }
 }
 
-function writeSchemaUriMapping(schemaUrl: string, fileUri: string): void {
+async function writeSchemaUriMappings(schemaUrls: string[], fileUri: string): Promise<void> {
   const yamlConfiguration = workspace.getConfiguration('yaml');
   const settings: Record<string, unknown> = yamlConfiguration.get('schemas');
   const disableSchemaDetection = yamlConfiguration.get('disableSchemaDetection');
   const filePatterns = getFilePatternCandidates(fileUri);
-  yamlConfiguration.update('disableSchemaDetection', removeFilePatternFromSetting(disableSchemaDetection, filePatterns));
+  await yamlConfiguration.update('disableSchemaDetection', removeFilePatternFromSetting(disableSchemaDetection, filePatterns));
   const newSettings = Object.assign({}, settings);
   deleteExistingFilePattern(newSettings, filePatterns);
-  const schemaSettings = newSettings[schemaUrl];
-  if (schemaSettings) {
-    if (Array.isArray(schemaSettings)) {
-      (schemaSettings as Array<string>).push(fileUri);
-    } else if (typeof schemaSettings === 'string') {
-      newSettings[schemaUrl] = [schemaSettings, fileUri];
+
+  for (const schemaUrl of schemaUrls) {
+    const schemaSettings = newSettings[schemaUrl];
+    if (schemaSettings) {
+      if (Array.isArray(schemaSettings)) {
+        const schemaFilePatterns = schemaSettings.filter((value): value is string => typeof value === 'string');
+        if (!schemaFilePatterns.includes(fileUri)) {
+          schemaFilePatterns.push(fileUri);
+        }
+        newSettings[schemaUrl] = schemaFilePatterns;
+      } else if (typeof schemaSettings === 'string') {
+        newSettings[schemaUrl] = schemaSettings === fileUri ? schemaSettings : [schemaSettings, fileUri];
+      }
+    } else {
+      newSettings[schemaUrl] = fileUri;
     }
-  } else {
-    newSettings[schemaUrl] = fileUri;
   }
-  yamlConfiguration.update('schemas', newSettings);
+  await yamlConfiguration.update('schemas', newSettings);
 }
 
-function writeDisableSchemaDetectionMapping(fileUri: string): void {
+async function writeDisableSchemaDetectionMapping(fileUri: string): Promise<void> {
   const yamlConfiguration = workspace.getConfiguration('yaml');
   const disableSchemaDetection = yamlConfiguration.get('disableSchemaDetection');
-  yamlConfiguration.update('disableSchemaDetection', addFilePatternToSetting(disableSchemaDetection, fileUri));
+  await yamlConfiguration.update('disableSchemaDetection', addFilePatternToSetting(disableSchemaDetection, fileUri));
 }
 
-function handleSchemaVersionSelection(schema: MatchingJSONSchema, fileUri: string): void {
+function handleSchemaVersionSelection(schema: MatchingJSONSchema, fileUri: string, selectedSchemaUris: string[]): void {
   const versionPick = window.createQuickPick<SchemaVersionItem>();
   const versionItems: SchemaVersionItem[] = [];
   const usedVersion = findUsedVersion(schema.versions, schema.uri);
@@ -313,13 +334,18 @@ function handleSchemaVersionSelection(schema: MatchingJSONSchema, fileUri: strin
   }
 
   versionPick.items = versionItems;
-  versionPick.title = `Select JSON Schema version for ${schema.name}`;
+  versionPick.title = `Select JSON Schema version for ${schema.name ?? schema.uri}`;
   versionPick.placeholder = 'Version';
   versionPick.onDidHide(() => versionPick.dispose());
 
-  versionPick.onDidChangeSelection((items) => {
+  versionPick.onDidChangeSelection(async (items) => {
     if (items && items.length === 1) {
-      writeSchemaUriMapping(items[0].url, fileUri);
+      const schemaVersionUris = new Set(Object.values(schema.versions ?? {}));
+      const remainingSchemaUris = selectedSchemaUris.filter(
+        (schemaUri) => schemaUri !== schema.uri && !schemaVersionUris.has(schemaUri)
+      );
+      const updatedSchemaUris = Array.from(new Set([...remainingSchemaUris, items[0].url]));
+      await writeSchemaUriMappings(updatedSchemaUris, fileUri);
     }
     versionPick.hide();
   });

--- a/test/json-schema-selection.test.ts
+++ b/test/json-schema-selection.test.ts
@@ -74,7 +74,7 @@ describe('Status bar should work in multiple different scenarios', () => {
     const statusBar = ({ show: sandbox.stub(), hide: sandbox.stub() } as unknown) as vscode.StatusBarItem;
     createStatusBarItemStub.returns(statusBar);
     onDidChangeActiveTextEditorStub.returns({});
-    clcStub.sendRequest.resolves([{ uri: 'https://foo.com/bar.json', name: 'bar schema' }]);
+    clcStub.sendRequest.resolves([{ uri: 'https://foo.com/bar.json', name: 'bar schema', usedForCurrentFile: true }]);
 
     createJSONSchemaStatusBarItem(context, (clcStub as unknown) as CommonLanguageClient);
     const callBackFn = onDidChangeActiveTextEditorStub.firstCall.firstArg;
@@ -198,7 +198,7 @@ describe('Status bar should work in multiple different scenarios', () => {
     expect(statusBar.show).calledOnce;
   });
 
-  it('Should include No JSON Schema in schema selection', async () => {
+  it('Should include "No JSON Schema" in schema selection', async () => {
     const context: vscode.ExtensionContext = {
       subscriptions: [],
     } as vscode.ExtensionContext;
@@ -206,7 +206,7 @@ describe('Status bar should work in multiple different scenarios', () => {
     const quickPick = createQuickPickStubValue<TestSchemaItem>();
     createStatusBarItemStub.returns(statusBar);
     createQuickPickStub.returns(quickPick);
-    clcStub.sendRequest.resolves([{ uri: 'https://foo.com/bar.json', name: 'bar schema' }]);
+    clcStub.sendRequest.resolves([{ uri: 'https://foo.com/bar.json', name: 'bar schema', usedForCurrentFile: true }]);
     activeTextEditor = ({
       document: { languageId: 'yaml', uri: vscode.Uri.parse('/foo.yaml') },
     } as unknown) as vscode.TextEditor;
@@ -472,7 +472,7 @@ describe('Status bar should work in multiple different scenarios', () => {
     expect(quickPick.hide).calledOnce;
   });
 
-  it('Should use No JSON Schema when all schemas are deselected', async () => {
+  it('Should use and auto-select "No JSON Schema" when all schemas are deselected', async () => {
     const context: vscode.ExtensionContext = {
       subscriptions: [],
     } as vscode.ExtensionContext;
@@ -498,6 +498,7 @@ describe('Status bar should work in multiple different scenarios', () => {
     await command();
     expect(quickPick.selectedItems).has.length(1);
     quickPick.select([]);
+    expect(quickPick.selectedItems).to.deep.equal([quickPick.items[0]]);
     await quickPick.accept();
 
     expect(update).calledWith('disableSchemaDetection', ['file:///foo.yaml']);
@@ -505,7 +506,7 @@ describe('Status bar should work in multiple different scenarios', () => {
     expect(quickPick.hide).calledOnce;
   });
 
-  it('Should let No JSON Schema override other selected schemas', async () => {
+  it('Should auto-deselect all other selected schemas when "No JSON Schema" is selected', async () => {
     const context: vscode.ExtensionContext = {
       subscriptions: [],
     } as vscode.ExtensionContext;
@@ -514,7 +515,7 @@ describe('Status bar should work in multiple different scenarios', () => {
     const update = sandbox.stub();
     createStatusBarItemStub.returns(statusBar);
     createQuickPickStub.returns(quickPick);
-    clcStub.sendRequest.resolves([{ uri: 'https://foo.com/bar.json', name: 'bar schema' }]);
+    clcStub.sendRequest.resolves([{ uri: 'https://foo.com/bar.json', name: 'bar schema', usedForCurrentFile: true }]);
     activeTextEditor = ({
       document: { languageId: 'yaml', uri: vscode.Uri.parse('/foo.yaml') },
     } as unknown) as vscode.TextEditor;
@@ -532,11 +533,52 @@ describe('Status bar should work in multiple different scenarios', () => {
     const noSchemaItem = quickPick.items[0];
     const schemaItem = quickPick.items.find((item) => item.schema);
     expect(schemaItem).to.exist;
-    quickPick.select([noSchemaItem, schemaItem as TestSchemaItem]);
+    expect(quickPick.selectedItems).to.deep.equal([schemaItem]);
+    quickPick.select([schemaItem as TestSchemaItem, noSchemaItem]);
+    expect(quickPick.selectedItems).to.deep.equal([noSchemaItem]);
     await quickPick.accept();
 
     expect(update).calledWith('disableSchemaDetection', ['file:///foo.yaml']);
     expect(update).not.calledWith('schemas');
+    expect(quickPick.hide).calledOnce;
+  });
+
+  it('Should deselect "No JSON Schema" when a schema is selected', async () => {
+    const context: vscode.ExtensionContext = {
+      subscriptions: [],
+    } as vscode.ExtensionContext;
+    const statusBar = ({ show: sandbox.stub(), hide: sandbox.stub() } as unknown) as vscode.StatusBarItem;
+    const quickPick = createQuickPickStubValue<TestSchemaItem>();
+    const update = sandbox.stub();
+    const get = sandbox.stub();
+    get.withArgs('disableSchemaDetection').returns([]);
+    get.withArgs('schemas').returns({});
+    createStatusBarItemStub.returns(statusBar);
+    createQuickPickStub.returns(quickPick);
+    clcStub.sendRequest.resolves([{ uri: 'https://foo.com/bar.json', name: 'bar schema' }]);
+    activeTextEditor = ({
+      document: { languageId: 'yaml', uri: vscode.Uri.parse('/foo.yaml') },
+    } as unknown) as vscode.TextEditor;
+    sandbox
+      .stub(vscode.workspace, 'getConfiguration')
+      .withArgs('yaml')
+      .returns(({
+        get,
+        update,
+      } as unknown) as vscode.WorkspaceConfiguration);
+
+    createJSONSchemaStatusBarItem(context, (clcStub as unknown) as CommonLanguageClient);
+    const command = registerCommandStub.firstCall.args[1];
+    await command();
+    const noSchemaItem = quickPick.items[0];
+    const schemaItem = quickPick.items.find((item) => item.schema);
+    expect(schemaItem).to.exist;
+    quickPick.select([noSchemaItem, schemaItem as TestSchemaItem]);
+    expect(quickPick.selectedItems).to.deep.equal([schemaItem]);
+    await quickPick.accept();
+
+    expect(update).calledWith('disableSchemaDetection', []);
+    expect(update).calledWith('schemas', { 'https://foo.com/bar.json': 'file:///foo.yaml' });
     expect(quickPick.hide).calledOnce;
   });
 

--- a/test/json-schema-selection.test.ts
+++ b/test/json-schema-selection.test.ts
@@ -19,21 +19,30 @@ interface TestSchemaItem extends vscode.QuickPickItem {
   schema?: unknown;
 }
 
+interface TestSchemaVersionItem extends vscode.QuickPickItem {
+  version?: string;
+  url?: string;
+}
+
 describe('Status bar should work in multiple different scenarios', () => {
   const sandbox = sinon.createSandbox();
   let clcStub: sinon.SinonStubbedInstance<TestLanguageClient>;
   let registerCommandStub: sinon.SinonStub;
   let createStatusBarItemStub: sinon.SinonStub;
   let onDidChangeActiveTextEditorStub: sinon.SinonStub;
+  let onDidChangeTextDocumentStub: sinon.SinonStub;
   let createQuickPickStub: sinon.SinonStub;
   let activeTextEditor: vscode.TextEditor | undefined;
 
   beforeEach(() => {
     clcStub = sandbox.stub(new TestLanguageClient());
     registerCommandStub = sandbox.stub(vscode.commands, 'registerCommand');
+    sandbox.stub(vscode.commands, 'executeCommand').resolves(undefined);
     createStatusBarItemStub = sandbox.stub(vscode.window, 'createStatusBarItem');
     createQuickPickStub = sandbox.stub(vscode.window, 'createQuickPick');
     onDidChangeActiveTextEditorStub = sandbox.stub(vscode.window, 'onDidChangeActiveTextEditor');
+    onDidChangeTextDocumentStub = sandbox.stub(vscode.workspace, 'onDidChangeTextDocument');
+    sandbox.stub(vscode.workspace, 'onDidChangeConfiguration').returns({ dispose: sandbox.stub() });
     activeTextEditor = undefined;
     sandbox.stub(vscode.window, 'activeTextEditor').get(() => activeTextEditor);
     sandbox.stub(jsonStatusBar, 'statusBarItem').returns(undefined);
@@ -55,7 +64,7 @@ describe('Status bar should work in multiple different scenarios', () => {
 
     expect(registerCommandStub).calledOnceWith('yaml.select.json.schema');
     expect(createStatusBarItemStub).calledOnceWith(vscode.StatusBarAlignment.Right);
-    expect(context.subscriptions).has.length(2);
+    expect(context.subscriptions).has.length(3);
   });
 
   it('Should update status bar on editor change', async () => {
@@ -72,9 +81,33 @@ describe('Status bar should work in multiple different scenarios', () => {
     await callBackFn({ document: { languageId: 'yaml', uri: vscode.Uri.parse('/foo.yaml') } });
 
     expect(statusBar.text).to.equal('bar schema');
-    expect(statusBar.tooltip).to.equal('Select JSON Schema');
+    expect(statusBar.tooltip).to.equal('Select JSON Schemas');
     expect(statusBar.backgroundColor).to.be.undefined;
     expect(statusBar.show).calledOnce;
+  });
+
+  it('Should update status bar on active YAML document change', async () => {
+    const context: vscode.ExtensionContext = {
+      subscriptions: [],
+    } as vscode.ExtensionContext;
+    const statusBar = ({ show: sandbox.stub(), hide: sandbox.stub() } as unknown) as vscode.StatusBarItem;
+    const document = { languageId: 'yaml', uri: vscode.Uri.parse('/foo.yaml') };
+    createStatusBarItemStub.returns(statusBar);
+    onDidChangeTextDocumentStub.returns({});
+    activeTextEditor = ({ document } as unknown) as vscode.TextEditor;
+    clcStub.sendRequest.resolves([{ uri: 'https://foo.com/modeline.json', name: 'modeline schema' }]);
+
+    createJSONSchemaStatusBarItem(context, (clcStub as unknown) as CommonLanguageClient);
+    const callBackFn = onDidChangeTextDocumentStub.firstCall.firstArg;
+    await callBackFn({
+      document,
+      contentChanges: [{ text: '# yaml-language-server: $schema=https://foo.com/modeline.json' }],
+    });
+    await waitForPromises();
+
+    expect(statusBar.text).to.equal('modeline schema');
+    expect(statusBar.tooltip).to.equal('Select JSON Schemas');
+    expect(statusBar.show).calledTwice;
   });
 
   it('Should inform if there are no schema', async () => {
@@ -91,7 +124,7 @@ describe('Status bar should work in multiple different scenarios', () => {
     await callBackFn({ document: { languageId: 'yaml', uri: vscode.Uri.parse('/foo.yaml') } });
 
     expect(statusBar.text).to.equal('No JSON Schema');
-    expect(statusBar.tooltip).to.equal('Select JSON Schema');
+    expect(statusBar.tooltip).to.equal('Select JSON Schemas');
     expect(statusBar.backgroundColor).to.be.undefined;
     expect(statusBar.show).calledOnce;
   });
@@ -103,15 +136,17 @@ describe('Status bar should work in multiple different scenarios', () => {
     const statusBar = ({ show: sandbox.stub(), hide: sandbox.stub() } as unknown) as vscode.StatusBarItem;
     createStatusBarItemStub.returns(statusBar);
     onDidChangeActiveTextEditorStub.returns({});
-    clcStub.sendRequest.resolves([{}, {}]);
+    clcStub.sendRequest.resolves([
+      { uri: 'https://foo.com/a.json', name: 'a schema' },
+      { uri: 'https://foo.com/b.json', name: 'b schema' },
+    ]);
 
     createJSONSchemaStatusBarItem(context, (clcStub as unknown) as CommonLanguageClient);
     const callBackFn = onDidChangeActiveTextEditorStub.firstCall.firstArg;
     await callBackFn({ document: { languageId: 'yaml', uri: vscode.Uri.parse('/foo.yaml') } });
 
-    expect(statusBar.text).to.equal('Multiple JSON Schemas...');
-    expect(statusBar.tooltip).to.equal('Multiple JSON Schema used to validate this file, click to select one');
-    expect(statusBar.backgroundColor).to.eql({ id: 'statusBarItem.warningBackground' });
+    expect(statusBar.text).to.equal('Multiple JSON Schemas');
+    expect(statusBar.tooltip).to.equal('Validated using 2 JSON schemas:\na schema\nb schema');
     expect(statusBar.show).calledOnce;
   });
 
@@ -134,7 +169,7 @@ describe('Status bar should work in multiple different scenarios', () => {
     await callBackFn({ document: { languageId: 'yaml', uri: vscode.Uri.parse('/foo.yaml') } });
 
     expect(statusBar.text).to.equal('bar schema(1.0.0)');
-    expect(statusBar.tooltip).to.equal('Select JSON Schema');
+    expect(statusBar.tooltip).to.equal('Select JSON Schemas');
     expect(statusBar.backgroundColor).to.be.undefined;
     expect(statusBar.show).calledOnce;
   });
@@ -158,7 +193,7 @@ describe('Status bar should work in multiple different scenarios', () => {
     await callBackFn({ document: { languageId: 'yaml', uri: vscode.Uri.parse('/foo.yaml') } });
 
     expect(statusBar.text).to.equal('bar schema(1.0.0)');
-    expect(statusBar.tooltip).to.equal('Select JSON Schema');
+    expect(statusBar.tooltip).to.equal('Select JSON Schemas');
     expect(statusBar.backgroundColor).to.be.undefined;
     expect(statusBar.show).calledOnce;
   });
@@ -181,7 +216,105 @@ describe('Status bar should work in multiple different scenarios', () => {
     await command();
 
     expect(quickPick.items[0].label).to.equal('No JSON Schema');
+    expect(quickPick.canSelectMany).to.be.true;
     expect(quickPick.show).calledOnce;
+  });
+
+  it('Should add a version button to schemas with versions', async () => {
+    const context: vscode.ExtensionContext = {
+      subscriptions: [],
+    } as vscode.ExtensionContext;
+    const statusBar = ({ show: sandbox.stub(), hide: sandbox.stub() } as unknown) as vscode.StatusBarItem;
+    const quickPick = createQuickPickStubValue<TestSchemaItem>();
+    createStatusBarItemStub.returns(statusBar);
+    createQuickPickStub.returns(quickPick);
+    clcStub.sendRequest.resolves([
+      {
+        uri: 'https://foo.com/a-v1.json',
+        name: 'a schema',
+        versions: {
+          '1.0.0': 'https://foo.com/a-v1.json',
+          '2.0.0': 'https://foo.com/a-v2.json',
+        },
+      },
+      { uri: 'https://foo.com/b.json', name: 'b schema' },
+    ]);
+    activeTextEditor = ({
+      document: { languageId: 'yaml', uri: vscode.Uri.parse('/foo.yaml') },
+    } as unknown) as vscode.TextEditor;
+    sandbox
+      .stub(vscode.workspace, 'getConfiguration')
+      .withArgs('yaml')
+      .returns(({
+        get: sandbox.stub().withArgs('disableSchemaDetection').returns([]),
+      } as unknown) as vscode.WorkspaceConfiguration);
+
+    createJSONSchemaStatusBarItem(context, (clcStub as unknown) as CommonLanguageClient);
+    const command = registerCommandStub.firstCall.args[1];
+    await command();
+    const versionedSchemaItem = quickPick.items.find(
+      (item) => (item.schema as { uri?: string })?.uri === 'https://foo.com/a-v1.json'
+    );
+    const unversionedSchemaItem = quickPick.items.find(
+      (item) => (item.schema as { uri?: string })?.uri === 'https://foo.com/b.json'
+    );
+
+    expect(quickPick.items.some((item) => item.label === 'Select Different Version')).to.be.false;
+    expect(versionedSchemaItem?.buttons).to.have.length(1);
+    expect(versionedSchemaItem?.buttons?.[0].tooltip).to.equal('Select schema version');
+    expect(unversionedSchemaItem?.buttons).to.be.undefined;
+  });
+
+  it('Should select "No JSON Schema" when no schema is used for the current file', async () => {
+    const context: vscode.ExtensionContext = {
+      subscriptions: [],
+    } as vscode.ExtensionContext;
+    const statusBar = ({ show: sandbox.stub(), hide: sandbox.stub() } as unknown) as vscode.StatusBarItem;
+    const quickPick = createQuickPickStubValue<TestSchemaItem>();
+    createStatusBarItemStub.returns(statusBar);
+    createQuickPickStub.returns(quickPick);
+    clcStub.sendRequest.resolves([{ uri: 'https://foo.com/bar.json', name: 'bar schema' }]);
+    activeTextEditor = ({
+      document: { languageId: 'yaml', uri: vscode.Uri.parse('/foo.yaml') },
+    } as unknown) as vscode.TextEditor;
+    sandbox
+      .stub(vscode.workspace, 'getConfiguration')
+      .withArgs('yaml')
+      .returns(({
+        get: sandbox.stub().withArgs('disableSchemaDetection').returns([]),
+      } as unknown) as vscode.WorkspaceConfiguration);
+
+    createJSONSchemaStatusBarItem(context, (clcStub as unknown) as CommonLanguageClient);
+    const command = registerCommandStub.firstCall.args[1];
+    await command();
+
+    expect(quickPick.selectedItems).to.deep.equal([quickPick.items[0]]);
+  });
+
+  it('Should keep "No JSON Schema" selected when schema detection is disabled for the current file', async () => {
+    const context: vscode.ExtensionContext = {
+      subscriptions: [],
+    } as vscode.ExtensionContext;
+    const statusBar = ({ show: sandbox.stub(), hide: sandbox.stub() } as unknown) as vscode.StatusBarItem;
+    const quickPick = createQuickPickStubValue<TestSchemaItem>();
+    createStatusBarItemStub.returns(statusBar);
+    createQuickPickStub.returns(quickPick);
+    clcStub.sendRequest.resolves([{ uri: 'https://foo.com/bar.json', name: 'bar schema', usedForCurrentFile: true }]);
+    activeTextEditor = ({
+      document: { languageId: 'yaml', uri: vscode.Uri.parse('/foo.yaml') },
+    } as unknown) as vscode.TextEditor;
+    sandbox
+      .stub(vscode.workspace, 'getConfiguration')
+      .withArgs('yaml')
+      .returns(({
+        get: sandbox.stub().withArgs('disableSchemaDetection').returns(['file:///foo.yaml']),
+      } as unknown) as vscode.WorkspaceConfiguration);
+
+    createJSONSchemaStatusBarItem(context, (clcStub as unknown) as CommonLanguageClient);
+    const command = registerCommandStub.firstCall.args[1];
+    await command();
+
+    expect(quickPick.selectedItems).to.deep.equal([quickPick.items[0]]);
   });
 
   it('Should write disableSchemaDetection when No JSON Schema is selected', async () => {
@@ -209,6 +342,7 @@ describe('Status bar should work in multiple different scenarios', () => {
     const command = registerCommandStub.firstCall.args[1];
     await command();
     quickPick.select([quickPick.items[0]]);
+    await quickPick.accept();
 
     expect(update).calledWith('disableSchemaDetection', ['file:///foo.yaml']);
     expect(quickPick.hide).calledOnce;
@@ -244,6 +378,7 @@ describe('Status bar should work in multiple different scenarios', () => {
     const schemaItem = quickPick.items.find((item) => item.schema);
     expect(schemaItem).to.exist;
     quickPick.select([schemaItem as TestSchemaItem]);
+    await quickPick.accept();
 
     expect(update).calledWith('disableSchemaDetection', ['file:///other.yaml']);
     expect(update).calledWith('schemas', { 'https://foo.com/bar.json': 'file:///foo.yaml' });
@@ -284,6 +419,7 @@ describe('Status bar should work in multiple different scenarios', () => {
     const schemaItem = quickPick.items.find((item) => (item.schema as { uri?: string })?.uri === 'https://foo.com/new.json');
     expect(schemaItem).to.exist;
     quickPick.select([schemaItem as TestSchemaItem]);
+    await quickPick.accept();
 
     expect(update).calledWith('disableSchemaDetection', ['file:///other.yaml']);
     expect(update).calledWith('schemas', {
@@ -292,13 +428,192 @@ describe('Status bar should work in multiple different scenarios', () => {
     });
     expect(quickPick.hide).calledOnce;
   });
+
+  it('Should write multiple selected schemas for the current file', async () => {
+    const context: vscode.ExtensionContext = {
+      subscriptions: [],
+    } as vscode.ExtensionContext;
+    const statusBar = ({ show: sandbox.stub(), hide: sandbox.stub() } as unknown) as vscode.StatusBarItem;
+    const quickPick = createQuickPickStubValue<TestSchemaItem>();
+    const update = sandbox.stub();
+    const get = sandbox.stub();
+    get.withArgs('disableSchemaDetection').returns([]);
+    get.withArgs('schemas').returns({});
+    createStatusBarItemStub.returns(statusBar);
+    createQuickPickStub.returns(quickPick);
+    clcStub.sendRequest.resolves([
+      { uri: 'https://foo.com/a.json', name: 'a schema' },
+      { uri: 'https://foo.com/b.json', name: 'b schema' },
+    ]);
+    activeTextEditor = ({
+      document: { languageId: 'yaml', uri: vscode.Uri.parse('/foo.yaml') },
+    } as unknown) as vscode.TextEditor;
+    sandbox
+      .stub(vscode.workspace, 'getConfiguration')
+      .withArgs('yaml')
+      .returns(({
+        get,
+        update,
+      } as unknown) as vscode.WorkspaceConfiguration);
+
+    createJSONSchemaStatusBarItem(context, (clcStub as unknown) as CommonLanguageClient);
+    const command = registerCommandStub.firstCall.args[1];
+    await command();
+    const schemaItems = quickPick.items.filter((item) => item.schema);
+    expect(schemaItems).has.length(2);
+    quickPick.select(schemaItems as TestSchemaItem[]);
+    await quickPick.accept();
+
+    expect(update).calledWith('disableSchemaDetection', []);
+    expect(update).calledWith('schemas', {
+      'https://foo.com/a.json': 'file:///foo.yaml',
+      'https://foo.com/b.json': 'file:///foo.yaml',
+    });
+    expect(quickPick.hide).calledOnce;
+  });
+
+  it('Should use No JSON Schema when all schemas are deselected', async () => {
+    const context: vscode.ExtensionContext = {
+      subscriptions: [],
+    } as vscode.ExtensionContext;
+    const statusBar = ({ show: sandbox.stub(), hide: sandbox.stub() } as unknown) as vscode.StatusBarItem;
+    const quickPick = createQuickPickStubValue<TestSchemaItem>();
+    const update = sandbox.stub();
+    createStatusBarItemStub.returns(statusBar);
+    createQuickPickStub.returns(quickPick);
+    clcStub.sendRequest.resolves([{ uri: 'https://foo.com/bar.json', name: 'bar schema', usedForCurrentFile: true }]);
+    activeTextEditor = ({
+      document: { languageId: 'yaml', uri: vscode.Uri.parse('/foo.yaml') },
+    } as unknown) as vscode.TextEditor;
+    sandbox
+      .stub(vscode.workspace, 'getConfiguration')
+      .withArgs('yaml')
+      .returns(({
+        get: sandbox.stub().withArgs('disableSchemaDetection').returns([]),
+        update,
+      } as unknown) as vscode.WorkspaceConfiguration);
+
+    createJSONSchemaStatusBarItem(context, (clcStub as unknown) as CommonLanguageClient);
+    const command = registerCommandStub.firstCall.args[1];
+    await command();
+    expect(quickPick.selectedItems).has.length(1);
+    quickPick.select([]);
+    await quickPick.accept();
+
+    expect(update).calledWith('disableSchemaDetection', ['file:///foo.yaml']);
+    expect(update).not.calledWith('schemas');
+    expect(quickPick.hide).calledOnce;
+  });
+
+  it('Should let No JSON Schema override other selected schemas', async () => {
+    const context: vscode.ExtensionContext = {
+      subscriptions: [],
+    } as vscode.ExtensionContext;
+    const statusBar = ({ show: sandbox.stub(), hide: sandbox.stub() } as unknown) as vscode.StatusBarItem;
+    const quickPick = createQuickPickStubValue<TestSchemaItem>();
+    const update = sandbox.stub();
+    createStatusBarItemStub.returns(statusBar);
+    createQuickPickStub.returns(quickPick);
+    clcStub.sendRequest.resolves([{ uri: 'https://foo.com/bar.json', name: 'bar schema' }]);
+    activeTextEditor = ({
+      document: { languageId: 'yaml', uri: vscode.Uri.parse('/foo.yaml') },
+    } as unknown) as vscode.TextEditor;
+    sandbox
+      .stub(vscode.workspace, 'getConfiguration')
+      .withArgs('yaml')
+      .returns(({
+        get: sandbox.stub().withArgs('disableSchemaDetection').returns([]),
+        update,
+      } as unknown) as vscode.WorkspaceConfiguration);
+
+    createJSONSchemaStatusBarItem(context, (clcStub as unknown) as CommonLanguageClient);
+    const command = registerCommandStub.firstCall.args[1];
+    await command();
+    const noSchemaItem = quickPick.items[0];
+    const schemaItem = quickPick.items.find((item) => item.schema);
+    expect(schemaItem).to.exist;
+    quickPick.select([noSchemaItem, schemaItem as TestSchemaItem]);
+    await quickPick.accept();
+
+    expect(update).calledWith('disableSchemaDetection', ['file:///foo.yaml']);
+    expect(update).not.calledWith('schemas');
+    expect(quickPick.hide).calledOnce;
+  });
+
+  it('Should select a schema version using the schema item button and preserve other selected schemas', async () => {
+    const context: vscode.ExtensionContext = {
+      subscriptions: [],
+    } as vscode.ExtensionContext;
+    const statusBar = ({ show: sandbox.stub(), hide: sandbox.stub() } as unknown) as vscode.StatusBarItem;
+    const schemaPick = createQuickPickStubValue<TestSchemaItem>();
+    const versionPick = createQuickPickStubValue<TestSchemaVersionItem>();
+    const update = sandbox.stub();
+    const get = sandbox.stub();
+    get.withArgs('disableSchemaDetection').returns([]);
+    get.withArgs('schemas').returns({});
+    createStatusBarItemStub.returns(statusBar);
+    createQuickPickStub.onFirstCall().returns(schemaPick);
+    createQuickPickStub.onSecondCall().returns(versionPick);
+    clcStub.sendRequest.resolves([
+      {
+        uri: 'https://foo.com/a-v1.json',
+        name: 'a schema',
+        usedForCurrentFile: true,
+        versions: {
+          '1.0.0': 'https://foo.com/a-v1.json',
+          '2.0.0': 'https://foo.com/a-v2.json',
+        },
+      },
+      { uri: 'https://foo.com/b.json', name: 'b schema', usedForCurrentFile: true },
+    ]);
+    activeTextEditor = ({
+      document: { languageId: 'yaml', uri: vscode.Uri.parse('/foo.yaml') },
+    } as unknown) as vscode.TextEditor;
+    sandbox
+      .stub(vscode.workspace, 'getConfiguration')
+      .withArgs('yaml')
+      .returns(({
+        get,
+        update,
+      } as unknown) as vscode.WorkspaceConfiguration);
+
+    createJSONSchemaStatusBarItem(context, (clcStub as unknown) as CommonLanguageClient);
+    const command = registerCommandStub.firstCall.args[1];
+    await command();
+    const versionedSchemaItem = schemaPick.items.find(
+      (item) => (item.schema as { uri?: string })?.uri === 'https://foo.com/a-v1.json'
+    );
+    expect(versionedSchemaItem?.buttons).to.have.length(1);
+    await schemaPick.triggerItemButton(versionedSchemaItem as TestSchemaItem, versionedSchemaItem.buttons[0]);
+
+    const versionItem = versionPick.items.find((item) => item.version === '2.0.0');
+    expect(versionPick.title).to.equal('Select JSON Schema version for a schema');
+    expect(versionItem).to.exist;
+    await versionPick.select([versionItem as TestSchemaVersionItem]);
+
+    expect(schemaPick.hide).calledOnce;
+    expect(update).calledWith('disableSchemaDetection', []);
+    expect(update).calledWith('schemas', {
+      'https://foo.com/b.json': 'file:///foo.yaml',
+      'https://foo.com/a-v2.json': 'file:///foo.yaml',
+    });
+    expect(versionPick.hide).calledOnce;
+  });
 });
 
-function createQuickPickStubValue<T extends vscode.QuickPickItem>(): vscode.QuickPick<T> & { select: (items: T[]) => void } {
+function createQuickPickStubValue<T extends vscode.QuickPickItem>(): vscode.QuickPick<T> & {
+  accept: () => Promise<void>;
+  select: (items: T[]) => Promise<void>;
+  triggerItemButton: (item: T, button: vscode.QuickInputButton) => Promise<void>;
+} {
+  let acceptHandler: () => void | Promise<void>;
+  let itemButtonHandler: (event: vscode.QuickPickItemButtonEvent<T>) => void | Promise<void>;
   let selectionHandler: (items: readonly T[]) => void;
   let hideHandler: () => void;
   const quickPick = {
     items: [] as readonly T[],
+    selectedItems: [] as readonly T[],
+    canSelectMany: false,
     placeholder: '',
     title: '',
     show: sinon.stub(),
@@ -309,12 +624,33 @@ function createQuickPickStubValue<T extends vscode.QuickPickItem>(): vscode.Quic
       selectionHandler = handler;
       return { dispose: sinon.stub() };
     }),
-    select: (items: T[]) => selectionHandler(items),
+    onDidAccept: sinon.stub().callsFake((handler: () => void) => {
+      acceptHandler = handler;
+      return { dispose: sinon.stub() };
+    }),
+    onDidTriggerItemButton: sinon.stub().callsFake((handler: (event: vscode.QuickPickItemButtonEvent<T>) => void) => {
+      itemButtonHandler = handler;
+      return { dispose: sinon.stub() };
+    }),
+    accept: () => Promise.resolve(acceptHandler?.()),
+    select: (items: T[]) => {
+      quickPick.selectedItems = items;
+      return Promise.resolve(selectionHandler?.(items));
+    },
+    triggerItemButton: (item: T, button: vscode.QuickInputButton) => Promise.resolve(itemButtonHandler?.({ item, button })),
   };
   quickPick.hide.callsFake(() => hideHandler?.());
   quickPick.onDidHide.callsFake((handler: () => void) => {
     hideHandler = handler;
     return { dispose: sinon.stub() };
   });
-  return (quickPick as unknown) as vscode.QuickPick<T> & { select: (items: T[]) => void };
+  return (quickPick as unknown) as vscode.QuickPick<T> & {
+    accept: () => Promise<void>;
+    select: (items: T[]) => Promise<void>;
+    triggerItemButton: (item: T, button: vscode.QuickInputButton) => Promise<void>;
+  };
+}
+
+function waitForPromises(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
 }

--- a/test/json-schema-selection.test.ts
+++ b/test/json-schema-selection.test.ts
@@ -249,6 +249,49 @@ describe('Status bar should work in multiple different scenarios', () => {
     expect(update).calledWith('schemas', { 'https://foo.com/bar.json': 'file:///foo.yaml' });
     expect(quickPick.hide).calledOnce;
   });
+
+  it('Should replace existing exact schema mappings when a schema is selected', async () => {
+    const context: vscode.ExtensionContext = {
+      subscriptions: [],
+    } as vscode.ExtensionContext;
+    const statusBar = ({ show: sandbox.stub(), hide: sandbox.stub() } as unknown) as vscode.StatusBarItem;
+    const quickPick = createQuickPickStubValue<TestSchemaItem>();
+    const update = sandbox.stub();
+    const get = sandbox.stub();
+    get.withArgs('disableSchemaDetection').returns(['foo.yaml', 'file:///other.yaml']);
+    get.withArgs('schemas').returns({
+      'https://foo.com/old-a.json': 'foo.yaml',
+      'https://foo.com/old-b.json': ['foo.yaml', 'bar.yaml'],
+    });
+    createStatusBarItemStub.returns(statusBar);
+    createQuickPickStub.returns(quickPick);
+    clcStub.sendRequest.resolves([{ uri: 'https://foo.com/new.json', name: 'new schema' }]);
+    activeTextEditor = ({
+      document: { languageId: 'yaml', uri: vscode.Uri.parse('/workspace/foo.yaml') },
+    } as unknown) as vscode.TextEditor;
+    sandbox.stub(vscode.workspace, 'asRelativePath').returns('foo.yaml');
+    sandbox
+      .stub(vscode.workspace, 'getConfiguration')
+      .withArgs('yaml')
+      .returns(({
+        get,
+        update,
+      } as unknown) as vscode.WorkspaceConfiguration);
+
+    createJSONSchemaStatusBarItem(context, (clcStub as unknown) as CommonLanguageClient);
+    const command = registerCommandStub.firstCall.args[1];
+    await command();
+    const schemaItem = quickPick.items.find((item) => (item.schema as { uri?: string })?.uri === 'https://foo.com/new.json');
+    expect(schemaItem).to.exist;
+    quickPick.select([schemaItem as TestSchemaItem]);
+
+    expect(update).calledWith('disableSchemaDetection', ['file:///other.yaml']);
+    expect(update).calledWith('schemas', {
+      'https://foo.com/old-b.json': ['bar.yaml'],
+      'https://foo.com/new.json': 'file:///workspace/foo.yaml',
+    });
+    expect(quickPick.hide).calledOnce;
+  });
 });
 
 function createQuickPickStubValue<T extends vscode.QuickPickItem>(): vscode.QuickPick<T> & { select: (items: T[]) => void } {

--- a/test/ui-test/autocompletionTest.ts
+++ b/test/ui-test/autocompletionTest.ts
@@ -43,7 +43,9 @@ export function autocompletionTest(): void {
 
     after(async function () {
       this.timeout(5000);
-      await editor.save();
+      if (editor) {
+        await editor.save();
+      }
       await new EditorView().closeAllEditors();
       deleteFileInHomeDir(yamlFileName);
     });

--- a/test/ui-test/util/utility.ts
+++ b/test/ui-test/util/utility.ts
@@ -34,7 +34,7 @@ export function deleteFileInHomeDir(filename: string): void {
 }
 
 export async function getSchemaLabel(text: string): Promise<WebElement | undefined> {
-  const schemalabel = await new StatusBar().findElements(By.xpath('.//a[@aria-label="' + text + ', Select JSON Schema"]'));
+  const schemalabel = await new StatusBar().findElements(By.xpath('.//a[@aria-label="' + text + ', Select JSON Schemas"]'));
   return schemalabel[0];
 }
 

--- a/test/ui-test/util/utility.ts
+++ b/test/ui-test/util/utility.ts
@@ -15,7 +15,7 @@ export async function createCustomFile(path: string): Promise<TextEditor> {
   await input.confirm();
   await input.confirm();
   const editor = new TextEditor();
-  editor.save();
+  await editor.save();
   input = await InputBox.create();
   await input.setText(path);
   await input.confirm();
@@ -34,7 +34,9 @@ export function deleteFileInHomeDir(filename: string): void {
 }
 
 export async function getSchemaLabel(text: string): Promise<WebElement | undefined> {
-  const schemalabel = await new StatusBar().findElements(By.xpath('.//a[@aria-label="' + text + ', Select JSON Schemas"]'));
+  const schemalabel = await new StatusBar().findElements(
+    By.xpath('.//a[contains(@aria-label, "' + text + '") and contains(@aria-label, "Select JSON Schema")]')
+  );
   return schemalabel[0];
 }
 


### PR DESCRIPTION
### What does this PR do?

yaml-language-server supports validating a YAML file against multiple matching JSON schemas by creating an internal combined schema with JSON Schema `allOf`. Because multiple schemas can be valid for one YAML file, the schema picker should allow users to select or deselect multiple schemas instead of forcing a single choice.

This PR updates the schema picker behavior:
- supports selecting/deselecting multiple schemas from the schema picker
- treats "No JSON Schema" option as an override: if selected, other schema selections are ignored and schema detection is disabled for the current YAML file.
- status bar is updated when a modeline schema is added or changed in the current YAML file
- changed version selection to a per-schema action: to select a schema version, hover over a schema name in the picker, click the versions icon on the right to choose/see available versions:
  <img width="745" height="246" alt="Screenshot 2026-05-22 at 2 00 43 PM" src="https://github.com/user-attachments/assets/ea404266-9a9d-4377-ab25-6ce8036c9850" />

### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/vscode-yaml/issues/1249
Fixes https://github.com/redhat-developer/vscode-yaml/issues/983
Related to https://github.com/redhat-developer/yaml-language-server/pull/1260

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
- [x] New automated tests
- [x] Manual testing: tested with https://github.com/redhat-developer/yaml-language-server/pull/1260