### PR TITLE
Fix: status bar updates when editing inline `$schema` in YAML files

### DIFF
--- a/src/schema-status-bar-item.ts
+++ b/src/schema-status-bar-item.ts
@@ -46,6 +46,8 @@ const getJSONSchemasRequestType: RequestType<FileUri, MatchingJSONSchema[], {}> 
 // eslint-disable-next-line @typescript-eslint/ban-types
 const getSchemaRequestType: RequestType<FileUri, JSONSchema[], {}> = new RequestType('yaml/get/jsonSchema');
 
+const schemaDeclarationPattern = /(?:#\s*(?:yaml-language-server\s*:\s*)?\$schema\s*(?:=|:)|^[ \t]*["']?\$schema["']?\s*:)/m;
+
 export let statusBarItem: StatusBarItem;
 
 let client: CommonLanguageClient;
@@ -77,7 +79,13 @@ export function createJSONSchemaStatusBarItem(context: ExtensionContext, languag
       if (
         editor?.document.languageId === 'yaml' &&
         editor.document.uri.toString() === event.document.uri.toString() &&
-        event.contentChanges?.some((change) => /#\s*yaml-language-server:\s*\$schema=/.test(change.text))
+        event.contentChanges?.some((change) => {
+          if (schemaDeclarationPattern.test(change.text)) {
+            return true;
+          }
+          const changedLine = event.document.lineAt(change.range.start.line).text;
+          return schemaDeclarationPattern.test(changedLine);
+        })
       ) {
         updateStatusBar(editor);
       }

--- a/test/json-schema-selection.test.ts
+++ b/test/json-schema-selection.test.ts
@@ -110,6 +110,44 @@ describe('Status bar should work in multiple different scenarios', () => {
     expect(statusBar.show).calledTwice;
   });
 
+  it('Should update status bar when an inline schema changes', async () => {
+    const context: vscode.ExtensionContext = {
+      subscriptions: [],
+    } as vscode.ExtensionContext;
+    const statusBar = ({ show: sandbox.stub(), hide: sandbox.stub() } as unknown) as vscode.StatusBarItem;
+    const document = {
+      languageId: 'yaml',
+      uri: vscode.Uri.parse('/foo.yaml'),
+      lineAt: sandbox.stub().returns({ text: '$schema: https://foo.com/inline.json' }),
+    };
+    createStatusBarItemStub.returns(statusBar);
+    onDidChangeTextDocumentStub.returns({});
+    activeTextEditor = ({ document } as unknown) as vscode.TextEditor;
+    const getSchemaRequest = clcStub.sendRequest.withArgs(sinon.match.has('method', 'yaml/get/jsonSchema'), sinon.match.any);
+    getSchemaRequest.onFirstCall().resolves([{ uri: 'https://foo.com/old.json', name: 'old schema' }]);
+    getSchemaRequest.onSecondCall().resolves([{ uri: 'https://foo.com/inline.json', name: 'inline schema' }]);
+    clcStub.sendRequest.withArgs(sinon.match.has('method', 'yaml/get/all/jsonSchemas'), sinon.match.any).resolves([]);
+
+    createJSONSchemaStatusBarItem(context, (clcStub as unknown) as CommonLanguageClient);
+    await waitForPromises();
+    expect(statusBar.text).to.equal('old schema');
+
+    const callBackFn = onDidChangeTextDocumentStub.firstCall.firstArg;
+    await callBackFn({
+      document,
+      contentChanges: [
+        {
+          text: 'https://foo.com/inline.json',
+          range: new vscode.Range(0, 9, 0, 33),
+        },
+      ],
+    });
+    await waitForPromises();
+    expect(statusBar.text).to.equal('inline schema');
+    expect(statusBar.tooltip).to.equal('Select JSON Schemas');
+    expect(statusBar.show).calledTwice;
+  });
+
   it('Should inform if there are no schema', async () => {
     const context: vscode.ExtensionContext = {
       subscriptions: [],


### PR DESCRIPTION
### What does this PR do?

1. Before: status bar didn't update when you added inline `$schema` object to a YAML file
    Fix: status bar shows the schema immediately when you type it

2. Before: status bar only updated if you pasted the entire schema association line (modeline / inline `$schema` object) at once
    Fix: status bar updates as you type character-by-character

### What issues does this PR fix or reference?
Fixes a bug from https://github.com/redhat-developer/yaml-language-server/pull/970
Related to https://github.com/redhat-developer/yaml-language-server/pull/1290

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
- [x] New automated test
- [x] Tested manually with https://github.com/redhat-developer/yaml-language-server/pull/1290:
  - Create a schema file `schema.json`:
      ```json
      {
        "$schema": "https://json-schema.org/draft/2020-12/schema",
        "type": "object",
        "properties": {
          "$schema": {
            "type": "string"
          },
          "firstName": {
            "type": "string"
          }
        },
        "required": ["firstName"],
        "additionalProperties": false
      }
      ```
  - In YAML file, type the `$schema` object character-by-character:
      ```yaml
      $schema: ./schema.json
      firstName: d
      ```
  - Verify that status bar updates after typing the schema path