### PR TITLE
Keep automatic schema detection for more specific extensions out of user settings

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -26,10 +26,10 @@ jobs:
       - uses: actions/checkout@v4
 
       # Set up Node
-      - name: Use Node 20
+      - name: Use Node 22
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       # Run install dependencies
       - name: Install dependencies
@@ -84,10 +84,10 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node 20
+      - name: Use Node 22
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - name: Install dependencies
         run: npm ci
       - name: Update yaml-language-server
@@ -101,10 +101,10 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node 20
+      - name: Use Node 22
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - name: Install dependencies
         run: npm ci
       - name: Update yaml-language-server

--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ The substrings are matched against the diagnostic messages shown in the VS Code 
 
 Disabling schema validation stops schema-based diagnostics. The file is still parsed as YAML, so YAML syntax errors can still be reported.
 
+When another enabled extension provides more specific YAML support, the YAML Language Support extension automatically disables schema detection at runtime for the relevant file patterns, preventing its own schema-based validation from conflicting with that extension. Built-in integrations include [dbt](https://marketplace.visualstudio.com/items?itemName=dbtLabsInc.dbt), [Docker DX](https://marketplace.visualstudio.com/items?itemName=docker.docker), [GitHub Actions](https://marketplace.visualstudio.com/items?itemName=github.vscode-github-actions), or [Azure Pipelines](https://marketplace.visualstudio.com/items?itemName=ms-azure-devops.azure-pipelines).
+
 ### Using a modeline
 
 Disable schema validation for the current file by setting `$schema` to `none` in a modeline:

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@typescript-eslint/eslint-plugin": "^7.11.0",
         "@typescript-eslint/parser": "^7.11.0",
         "@vscode/test-cli": "^0.0.12",
-        "@vscode/test-electron": "^2.4.0",
+        "@vscode/test-electron": "^3.1.0",
         "@vscode/test-web": "^0.0.78",
         "buffer": "^6.0.3",
         "chai": "^4.2.0",
@@ -1373,9 +1373,9 @@
       }
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
-      "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+      "integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1386,7 +1386,7 @@
         "semver": "^7.6.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@vscode/test-web": {

--- a/package.json
+++ b/package.json
@@ -342,7 +342,7 @@
     "@typescript-eslint/eslint-plugin": "^7.11.0",
     "@typescript-eslint/parser": "^7.11.0",
     "@vscode/test-cli": "^0.0.12",
-    "@vscode/test-electron": "^2.4.0",
+    "@vscode/test-electron": "^3.1.0",
     "@vscode/test-web": "^0.0.78",
     "buffer": "^6.0.3",
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
             }
           ],
           "default": [],
-          "markdownDescription": "Disable schema detection for YAML files matching the configured glob pattern or list of glob patterns. Common patterns are automatically added when another enabled extension provides more specific YAML support, such as [dbt](https://marketplace.visualstudio.com/items?itemName=dbtLabsInc.dbt), [Docker DX](https://marketplace.visualstudio.com/items?itemName=docker.docker), [GitHub Actions](https://marketplace.visualstudio.com/items?itemName=github.vscode-github-actions), or [Azure Pipelines](https://marketplace.visualstudio.com/items?itemName=ms-azure-devops.azure-pipelines). Modelines still apply."
+          "markdownDescription": "Disable schema detection for YAML files matching the configured glob pattern or list of glob patterns. Modelines still apply."
         },
         "yaml.kubernetesCRDStore.enable": {
           "type": "boolean",

--- a/src/autoDisableSchemaDetection.ts
+++ b/src/autoDisableSchemaDetection.ts
@@ -2,8 +2,8 @@
  *  Copyright (c) IBM Corp. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { ConfigurationTarget, extensions, workspace } from 'vscode';
-import type { ExtensionContext, WorkspaceConfiguration } from 'vscode';
+import { extensions, workspace } from 'vscode';
+import type { ConfigurationRequest } from 'vscode-languageclient';
 
 interface AutoDisableSchemaDetectionEntry {
   extensionId: string;
@@ -47,58 +47,30 @@ const autoDisableSchemaDetectionEntries: AutoDisableSchemaDetectionEntry[] = [
   },
 ];
 
-export async function initializeAutoDisableSchemaDetection(context: ExtensionContext): Promise<void> {
-  await updateAutoDisableSchemaDetectionSetting();
-  context.subscriptions.push(
-    extensions.onDidChange(() => {
-      updateAutoDisableSchemaDetectionSetting();
-    }),
-    workspace.onDidChangeConfiguration((event) => {
-      if (
-        event.affectsConfiguration('docker.extension.enableComposeLanguageServer') ||
-        event.affectsConfiguration('yaml.disableSchemaDetection')
-      ) {
-        updateAutoDisableSchemaDetectionSetting();
-      }
-    })
-  );
-}
-
-async function updateAutoDisableSchemaDetectionSetting(): Promise<void> {
-  const configuration = workspace.getConfiguration('yaml');
-  const currentDisableSchemaDetection = getDisableSchemaDetectionSetting(configuration);
-  const update = computeAutoDisableSchemaDetectionUpdate(
-    currentDisableSchemaDetection.value,
-    getAutoDisabledSchemaDetectionExtensions()
-  );
-  if (
-    !(
-      currentDisableSchemaDetection.value.length === update.length &&
-      currentDisableSchemaDetection.value.every((value, index) => value === update[index])
-    )
-  ) {
-    await configuration.update('disableSchemaDetection', update, currentDisableSchemaDetection.target);
+export const applyAutoDisableSchemaDetection: ConfigurationRequest.MiddlewareSignature = async (params, token, configuration) => {
+  const configurations = await configuration(params, token);
+  if (!Array.isArray(configurations)) {
+    return configurations;
   }
-}
+  return configurations.map((configuration, index) => {
+    if (
+      params.items[index]?.section !== 'yaml' ||
+      configuration === null ||
+      typeof configuration !== 'object' ||
+      Array.isArray(configuration)
+    ) {
+      return configuration;
+    }
 
-function getDisableSchemaDetectionSetting(
-  configuration: WorkspaceConfiguration
-): {
-  value: string[];
-  target: ConfigurationTarget;
-} {
-  const inspected = configuration.inspect<string | string[]>('disableSchemaDetection');
-  if (inspected?.workspaceValue !== undefined) {
     return {
-      value: toStringArray(inspected.workspaceValue),
-      target: ConfigurationTarget.Workspace,
+      ...configuration,
+      disableSchemaDetection: computeAutoDisableSchemaDetectionUpdate(
+        configuration.disableSchemaDetection,
+        getAutoDisabledSchemaDetectionExtensions()
+      ),
     };
-  }
-  return {
-    value: toStringArray(inspected?.globalValue ?? []),
-    target: ConfigurationTarget.Global,
-  };
-}
+  });
+};
 
 export function getAutoDisabledSchemaDetectionExtensions(): string[] {
   const configuration = workspace.getConfiguration();
@@ -116,19 +88,13 @@ export function getAutoDisabledSchemaDetectionExtensions(): string[] {
 }
 
 export function computeAutoDisableSchemaDetectionUpdate(
-  currentDisableSchemaDetection: string[],
+  currentDisableSchemaDetection: string | string[],
   enabledExtensions: string[]
 ): string[] {
+  const configuredFileMatches = toStringArray(currentDisableSchemaDetection);
   const desiredFileMatches = getFileMatchesForExtensions(enabledExtensions);
-  const disabledExtensions = autoDisableSchemaDetectionEntries
-    .map((entry) => entry.extensionId)
-    .filter((extensionId) => !enabledExtensions.includes(extensionId));
-  const disabledFileMatches = getFileMatchesForExtensions(disabledExtensions);
-  const withoutInactiveManagedFileMatches = currentDisableSchemaDetection.filter(
-    (fileMatch) => !disabledFileMatches.includes(fileMatch) || desiredFileMatches.includes(fileMatch)
-  );
-  const additions = desiredFileMatches.filter((fileMatch) => !withoutInactiveManagedFileMatches.includes(fileMatch));
-  return withoutInactiveManagedFileMatches.concat(additions);
+  const additions = desiredFileMatches.filter((fileMatch) => !configuredFileMatches.includes(fileMatch));
+  return configuredFileMatches.concat(additions);
 }
 
 function getFileMatchesForExtensions(extensionIds: string[]): string[] {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@
 import { workspace, ExtensionContext, extensions, window, commands, Uri } from 'vscode';
 import {
   CommonLanguageClient,
+  DidChangeConfigurationNotification,
   LanguageClientOptions,
   NotificationType,
   RequestType,
@@ -21,7 +22,7 @@ import { getConflictingExtensions, showUninstallConflictsNotification } from './
 import { TelemetryErrorHandler, TelemetryOutputChannel } from './telemetry';
 import { createJSONSchemaStatusBarItem } from './schema-status-bar-item';
 import { initializeRecommendation } from './recommendation';
-import { initializeAutoDisableSchemaDetection } from './autoDisableSchemaDetection';
+import { applyAutoDisableSchemaDetection } from './autoDisableSchemaDetection';
 
 export interface ISchemaAssociations {
   [pattern: string]: string[];
@@ -141,11 +142,15 @@ export async function startClient(
     initializationOptions: {
       l10nPath,
     },
+    middleware: {
+      workspace: {
+        configuration: applyAutoDisableSchemaDetection,
+      },
+    },
   };
 
   // Create the language client and start it
   client = newLanguageClient('yaml', lsName, clientOptions);
-  await initializeAutoDisableSchemaDetection(context);
 
   const disposable = client.start();
 
@@ -176,6 +181,7 @@ export async function startClient(
 
       // If the extensions change, fire this notification again to pick up on any association changes
       extensions.onDidChange(() => {
+        client.sendNotification(DidChangeConfigurationNotification.type);
         client.sendNotification(SchemaAssociationNotification.type, getSchemaAssociations());
         findConflicts();
       });

--- a/test/autoDisableSchemaDetection.test.ts
+++ b/test/autoDisableSchemaDetection.test.ts
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) IBM Corp. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import type { ConfigurationRequest } from 'vscode-languageclient';
+import { applyAutoDisableSchemaDetection, computeAutoDisableSchemaDetectionUpdate } from '../src/autoDisableSchemaDetection';
+
+const expect = chai.expect;
+
+describe('Auto-disable schema detection', () => {
+  const sandbox = sinon.createSandbox();
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('combines configured and automatic patterns without duplicates', () => {
+    const result = computeAutoDisableSchemaDetectionUpdate('azure-pipelines.yml', ['ms-azure-devops.azure-pipelines']);
+    expect(result).to.deep.equal(['azure-pipelines.yml', 'azure-pipelines.yaml']);
+  });
+
+  it('preserves configured patterns when the corresponding extension is inactive', () => {
+    const result = computeAutoDisableSchemaDetectionUpdate(['azure-pipelines.yml', '**/custom.yml'], []);
+    expect(result).to.deep.equal(['azure-pipelines.yml', '**/custom.yml']);
+  });
+
+  it('adds automatic patterns only to the internal language server configuration', async () => {
+    const configuredYaml = {
+      disableSchemaDetection: ['**/custom.yml'],
+      validate: true,
+    };
+    sandbox
+      .stub(vscode.extensions, 'getExtension')
+      .callsFake((extensionId) =>
+        extensionId === 'ms-azure-devops.azure-pipelines' ? ({} as vscode.Extension<unknown>) : undefined
+      );
+    sandbox.stub(vscode.workspace, 'getConfiguration').returns(({
+      get: sandbox.stub(),
+    } as unknown) as vscode.WorkspaceConfiguration);
+    const configurations: ConfigurationRequest.HandlerSignature = sandbox.stub().resolves([configuredYaml]);
+
+    const result = await applyAutoDisableSchemaDetection(
+      {
+        items: [{ section: 'yaml' }],
+      },
+      new vscode.CancellationTokenSource().token,
+      configurations
+    );
+
+    expect(result).to.deep.equal([
+      {
+        disableSchemaDetection: ['**/custom.yml', 'azure-pipelines.yml', 'azure-pipelines.yaml'],
+        validate: true,
+      },
+    ]);
+    expect(configuredYaml).to.deep.equal({
+      disableSchemaDetection: ['**/custom.yml'],
+      validate: true,
+    });
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Previously, if another enabled extension provides more specific YAML support, file patterns associated with the extension were written directly to the user's `yaml.disableSchemaDetection` setting.

This PR keeps the automatic schema detection internal.

Also, updates `@vscode/test-electron` to fix macOS VSCode build issue (requires Node >= 22).

### What issues does this PR fix or reference?

Fixes https://github.com/redhat-developer/vscode-yaml/issues/1271

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
- [x] Automated tests
- [x] Tested manually 